### PR TITLE
Group OppfolgingstilfelleBitList into OppfolgingstilfelleList

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleService.kt
@@ -1,14 +1,51 @@
 package no.nav.syfo.oppfolgingstilfelle
 
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.Tag.SENDT
+import no.nav.syfo.oppfolgingstilfelle.bit.Tag.SYKEPENGESOKNAD
+import no.nav.syfo.oppfolgingstilfelle.bit.toOppfolgingstilfelleDagList
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
-import java.time.LocalDate
+import no.nav.syfo.oppfolgingstilfelle.domain.groupOppfolgingstilfelleList
+import java.time.LocalDateTime
+import java.util.*
 
 class OppfolgingstilfelleService {
-    fun oppfolgingstilfelleList() = listOf(
-        Oppfolgingstilfelle(
-            start = LocalDate.now().minusDays(1),
-            end = LocalDate.now().plusDays(1),
-            virksomhetsnummerList = emptyList(),
+    fun oppfolgingstilfelleList(
+        personIdentNumber: PersonIdentNumber,
+    ): List<Oppfolgingstilfelle> =
+        createOppfolgingstilfelleList(
+            oppfolgingstilfelleBitList = oppfolgingstilfelleBitList(personIdentNumber),
+        )
+
+    fun oppfolgingstilfelleBitList(
+        personIdentNumber: PersonIdentNumber,
+    ) = listOf(
+        OppfolgingstilfelleBit(
+            uuid = UUID.randomUUID(),
+            personIdentNumber = personIdentNumber,
+            virksomhetsnummer = "987654321",
+            createdAt = LocalDateTime.now(),
+            inntruffet = LocalDateTime.now().minusDays(1),
+            fom = LocalDateTime.now().minusDays(1),
+            tom = LocalDateTime.now().plusDays(1),
+            tagList = listOf(
+                SYKEPENGESOKNAD,
+                SENDT,
+            ),
+            ressursId = UUID.randomUUID().toString(),
         ),
     )
+
+    fun createOppfolgingstilfelleList(
+        oppfolgingstilfelleBitList: List<OppfolgingstilfelleBit>,
+    ): List<Oppfolgingstilfelle> {
+        return if (oppfolgingstilfelleBitList.isEmpty()) {
+            emptyList()
+        } else {
+            oppfolgingstilfelleBitList
+                .toOppfolgingstilfelleDagList()
+                .groupOppfolgingstilfelleList()
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApi.kt
@@ -24,7 +24,9 @@ fun Route.registerOppfolgingstilfelleApi(
                 ?: throw IllegalArgumentException("Could not retrieve OppfolgingstilfelleDTO: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
             val oppfolgingstilfellePersonDTO: OppfolgingstilfellePersonDTO =
-                oppfolgingstilfelleService.oppfolgingstilfelleList().toOppfolgingstilfellePersonDTO(
+                oppfolgingstilfelleService.oppfolgingstilfelleList(
+                    personIdentNumber = personIdentNumber,
+                ).toOppfolgingstilfellePersonDTO(
                     personIdentNumber = personIdentNumber,
                 )
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/Oppfolgingstilfellebit.kt
@@ -1,0 +1,137 @@
+package no.nav.syfo.oppfolgingstilfelle.bit
+
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBit.Companion.TAG_PRIORITY
+import no.nav.syfo.oppfolgingstilfelle.domain.OppfolgingstilfelleDag
+import no.nav.syfo.util.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+enum class Tag {
+    SYKMELDING,
+    NY,
+    BEKREFTET,
+    SENDT,
+    KORRIGERT,
+    AVBRUTT,
+    UTGAATT,
+    PERIODE,
+    FULL_AKTIVITET,
+    INGEN_AKTIVITET,
+    GRADERT_AKTIVITET,
+    BEHANDLINGSDAGER,
+    BEHANDLINGSDAG,
+    ANNET_FRAVAR,
+    SYKEPENGESOKNAD,
+    FERIE,
+    PERMISJON,
+    OPPHOLD_UTENFOR_NORGE,
+    EGENMELDING,
+    FRAVAR_FOR_SYKMELDING,
+    PAPIRSYKMELDING,
+    ARBEID_GJENNOPPTATT,
+    KORRIGERT_ARBEIDSTID,
+    UKJENT_AKTIVITET,
+    UTDANNING,
+    FULLTID,
+    DELTID,
+    REDUSERT_ARBEIDSGIVERPERIODE,
+    REISETILSKUDD,
+    AVVENTENDE,
+}
+
+data class OppfolgingstilfelleBit(
+    val uuid: UUID,
+    val personIdentNumber: PersonIdentNumber,
+    val virksomhetsnummer: String? = null,
+    val createdAt: LocalDateTime,
+    val inntruffet: LocalDateTime,
+    val tagList: List<Tag>,
+    val ressursId: String,
+    val fom: LocalDateTime,
+    val tom: LocalDateTime,
+) {
+    companion object {
+        val TAG_PRIORITY: List<ListContainsPredicate<Tag>> = listOf(
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.ARBEID_GJENNOPPTATT,
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.KORRIGERT_ARBEIDSTID and Tag.BEHANDLINGSDAGER,
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.KORRIGERT_ARBEIDSTID and Tag.FULL_AKTIVITET,
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.KORRIGERT_ARBEIDSTID and (Tag.GRADERT_AKTIVITET or Tag.INGEN_AKTIVITET),
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and (Tag.PERMISJON or Tag.FERIE),
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and (Tag.EGENMELDING or Tag.PAPIRSYKMELDING or Tag.FRAVAR_FOR_SYKMELDING),
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and ListContainsPredicate.tagsSize(2),
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.BEHANDLINGSDAG,
+            Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.BEHANDLINGSDAGER,
+            Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and Tag.BEHANDLINGSDAGER,
+            Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and Tag.FULL_AKTIVITET,
+            Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and (Tag.GRADERT_AKTIVITET or Tag.INGEN_AKTIVITET),
+            Tag.SYKMELDING and Tag.BEKREFTET and Tag.ANNET_FRAVAR,
+            Tag.SYKMELDING and Tag.SENDT and Tag.PERIODE and Tag.REISETILSKUDD and Tag.UKJENT_AKTIVITET,
+            Tag.SYKMELDING and Tag.NY and Tag.PERIODE and Tag.BEHANDLINGSDAGER,
+            Tag.SYKMELDING and Tag.NY and Tag.PERIODE and Tag.FULL_AKTIVITET,
+            Tag.SYKMELDING and Tag.NY and Tag.PERIODE and (Tag.GRADERT_AKTIVITET or Tag.INGEN_AKTIVITET),
+            Tag.SYKMELDING and Tag.NY and Tag.PERIODE and Tag.REISETILSKUDD and Tag.UKJENT_AKTIVITET,
+        )
+    }
+}
+
+fun List<OppfolgingstilfelleBit>.toOppfolgingstilfelleDagList(): List<OppfolgingstilfelleDag> {
+    require(this.isNotEmpty())
+
+    val firstFom = this.firstFom().toLocalDate()
+    val lastTom = this.lastTom().toLocalDate()
+
+    val numberOfDaysInOppfolgingstilleTimeline = (0..ChronoUnit.DAYS.between(firstFom, lastTom))
+
+    return numberOfDaysInOppfolgingstilleTimeline
+        .map { day ->
+            this.pickOppfolgingstilfelleDag(
+                dag = firstFom.plusDays(day),
+            )
+        }
+}
+
+fun List<OppfolgingstilfelleBit>.firstFom(): LocalDateTime =
+    this.minByOrNull { it.fom }!!.fom
+
+fun List<OppfolgingstilfelleBit>.lastTom(): LocalDateTime =
+    this.maxByOrNull { it.tom }!!.tom
+
+fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
+    dag: LocalDate,
+): OppfolgingstilfelleDag {
+    val bitListForDag = this.filter { bit ->
+        dag in (bit.fom.toLocalDate()..(bit.tom.toLocalDate()))
+    }
+    return bitListForDag
+        .groupBy { bit -> bit.inntruffet.toLocalDate() }
+        .toSortedMap()
+        .mapValues { entryDagBitList: Map.Entry<LocalDate, List<OppfolgingstilfelleBit>> ->
+            entryDagBitList.value.findPriorityOppfolgingstilfelleBitOrNull()
+        }
+        .mapNotNull(Map.Entry<LocalDate, OppfolgingstilfelleBit?>::value)
+        .map { bit ->
+            OppfolgingstilfelleDag(
+                dag = dag,
+                priorityOppfolgingstilfelleBit = bit,
+            )
+        }
+        .lastOrNull()
+        ?: OppfolgingstilfelleDag(
+            dag = dag,
+            priorityOppfolgingstilfelleBit = null,
+        )
+}
+
+fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitOrNull(): OppfolgingstilfelleBit? {
+    TAG_PRIORITY.forEach { tagPriorityElement ->
+        this.find { bit ->
+            bit.tagList in tagPriorityElement
+        }?.let { bit ->
+            return bit
+        }
+    }
+    return null
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.oppfolgingstilfelle.api.domain.OppfolgingstilfellePersonDTO
 import java.time.LocalDate
 
 data class Oppfolgingstilfelle(
+    val personIdentNumber: PersonIdentNumber,
     val start: LocalDate,
     val end: LocalDate,
     val virksomhetsnummerList: List<Virksomhetsnummer>,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/OppfolgingstilfelleDag.kt
@@ -1,0 +1,93 @@
+package no.nav.syfo.oppfolgingstilfelle.domain
+
+import no.nav.syfo.domain.Virksomhetsnummer
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.Tag
+import no.nav.syfo.util.and
+import no.nav.syfo.util.or
+import java.time.LocalDate
+
+class OppfolgingstilfelleDag(
+    val dag: LocalDate,
+    val priorityOppfolgingstilfelleBit: OppfolgingstilfelleBit?,
+)
+
+fun List<OppfolgingstilfelleDag>.groupOppfolgingstilfelleList(): List<Oppfolgingstilfelle> {
+    val oppfolgingstilfelleList = ArrayList<Oppfolgingstilfelle>()
+    var oppfolgingstilfelleSykedagList = ArrayList<OppfolgingstilfelleDag>()
+    var notSykedagSinceLastSykedagCounter = 0
+
+    this.forEach {
+        when {
+            it.isArbeidsdag() -> {
+                notSykedagSinceLastSykedagCounter++
+            }
+
+            it.isFeriedag() -> {
+                if (notSykedagSinceLastSykedagCounter > 0) {
+                    // Only count Feriedag if at least one Arbeidsdag since last Sykedag
+                    notSykedagSinceLastSykedagCounter++
+                }
+            }
+            else -> { // isSykedag
+                oppfolgingstilfelleSykedagList.add(it)
+                notSykedagSinceLastSykedagCounter = 0
+            }
+        }
+
+        val noSykedagLast16days = notSykedagSinceLastSykedagCounter >= 16 && oppfolgingstilfelleSykedagList.isNotEmpty()
+        if (noSykedagLast16days) {
+            val newOppfolgingstilfelle = Oppfolgingstilfelle(
+                personIdentNumber = this.mapNotNull { dag ->
+                    dag.priorityOppfolgingstilfelleBit?.personIdentNumber
+                }.first(),
+                start = oppfolgingstilfelleSykedagList.first().dag,
+                end = oppfolgingstilfelleSykedagList.last().dag,
+                virksomhetsnummerList = emptyList(),
+            )
+            oppfolgingstilfelleList.add(newOppfolgingstilfelle)
+
+            // Reset variables
+            oppfolgingstilfelleSykedagList = ArrayList()
+            notSykedagSinceLastSykedagCounter = 0
+        }
+    }
+
+    if (oppfolgingstilfelleSykedagList.isNotEmpty()) {
+        val virksomhetsnummerList: List<Virksomhetsnummer> = oppfolgingstilfelleSykedagList.mapNotNull {
+            it.priorityOppfolgingstilfelleBit?.virksomhetsnummer
+        }.distinct().map { virksomhetsnummer ->
+            Virksomhetsnummer(virksomhetsnummer)
+        }
+        val lastOppfolgingstilfelle = Oppfolgingstilfelle(
+            personIdentNumber = this.mapNotNull { dag -> dag.priorityOppfolgingstilfelleBit?.personIdentNumber }
+                .first(),
+            start = oppfolgingstilfelleSykedagList.first().dag,
+            end = oppfolgingstilfelleSykedagList.last().dag,
+            virksomhetsnummerList = virksomhetsnummerList,
+        )
+        oppfolgingstilfelleList.add(lastOppfolgingstilfelle)
+    }
+
+    return oppfolgingstilfelleList
+}
+
+fun OppfolgingstilfelleDag.isArbeidsdag() =
+    priorityOppfolgingstilfelleBit
+        ?.tagList
+        ?.let { tagList ->
+            tagList in (
+                (Tag.SYKMELDING and Tag.PERIODE and Tag.FULL_AKTIVITET)
+                    or (Tag.SYKEPENGESOKNAD and Tag.ARBEID_GJENNOPPTATT)
+                    or (Tag.SYKEPENGESOKNAD and Tag.BEHANDLINGSDAGER)
+                )
+        }
+        ?: true
+
+fun OppfolgingstilfelleDag.isFeriedag() =
+    priorityOppfolgingstilfelleBit
+        ?.tagList
+        ?.let { tagList ->
+            tagList in (Tag.SYKEPENGESOKNAD and (Tag.FERIE or Tag.PERMISJON))
+        }
+        ?: false

--- a/src/main/kotlin/no/nav/syfo/util/ListContainsPredicate.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ListContainsPredicate.kt
@@ -1,0 +1,37 @@
+package no.nav.syfo.util
+
+class ListContainsPredicate<T> private constructor(
+    private val predicate: (List<T>) -> Boolean,
+) {
+    companion object {
+        fun <T> of(t: T) = ListContainsPredicate<T> { t in it }
+
+        fun <T> tagsSize(size: Int) = ListContainsPredicate<T> { it.size == size }
+
+        fun <T> not(t: T) = not(of(t))
+
+        fun <T> not(lcp: ListContainsPredicate<T>) = ListContainsPredicate<T> { it !in lcp }
+    }
+
+    operator fun contains(listToTest: List<T>): Boolean = predicate(listToTest)
+
+    infix fun and(other: T) = and(of(other))
+
+    infix fun and(other: ListContainsPredicate<T>) = ListContainsPredicate<T> { it in this && it in other }
+
+    infix fun or(other: T) = or(of(other))
+
+    infix fun or(other: ListContainsPredicate<T>) = ListContainsPredicate<T> { it in this || it in other }
+
+    operator fun not() = ListContainsPredicate<T> { it !in this }
+}
+
+infix fun <T> T.or(other: ListContainsPredicate<T>) = ListContainsPredicate.of(this) or other
+
+infix fun <T> T.or(other: T) = ListContainsPredicate.of(this) or other
+
+infix fun <T> T.and(other: ListContainsPredicate<T>) = ListContainsPredicate.of(this) and other
+
+infix fun <T> T.and(other: T) = ListContainsPredicate.of(this) and other
+
+operator fun <T> T.not() = ListContainsPredicate.not(this)

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleServiceSpek.kt
@@ -1,0 +1,272 @@
+package no.nav.syfo.oppfolgingstilfelle
+
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.Tag.*
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testhelper.generator.generateOppfolgingstilfelleBit
+import java.time.*
+
+class OppfolgingstilfelleServiceSpek : Spek({
+    describe(OppfolgingstilfelleServiceSpek::class.java.simpleName) {
+
+        val oppfolgingstilfelleService = OppfolgingstilfelleService()
+
+        val monday = LocalDate.of(2018, 11, 26)
+        val defaultBit: OppfolgingstilfelleBit = generateOppfolgingstilfelleBit().copy(
+            createdAt = monday.atStartOfDay(),
+            inntruffet = monday.atStartOfDay(),
+            fom = monday.atStartOfDay(),
+        )
+
+        describe("Generate OppfolgingstilfelleList from OppfolgingsBitList") {
+            it("should return empty list of OppfolgingstilfelleBitList is empty") {
+                val result = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = emptyList(),
+                )
+                result shouldBeEqualTo emptyList()
+            }
+
+            it("should return 1 Oppfolgingstilfelle if person only has days with Sykedag") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(16),
+                        tom = LocalDateTime.now().minusDays(16),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now(),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 1
+
+                val tilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                tilfelleDuration shouldBeEqualTo 16
+            }
+
+            it("should return 1 Oppfolgingstilfelle, if person only has Ferie/Permisjon between 2 Sykedag") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(20),
+                        tom = LocalDateTime.now().minusDays(20),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, FERIE),
+                        fom = LocalDateTime.now().minusDays(19),
+                        tom = LocalDateTime.now().minusDays(10),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, PERMISJON),
+                        fom = LocalDateTime.now().minusDays(9),
+                        tom = LocalDateTime.now().minusDays(1),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now(),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 1
+
+                val tilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                tilfelleDuration shouldBeEqualTo 20
+            }
+
+            it("should return 1 Oppfolgingstilfelle, if person has less than 16 Arbeidsdag between sickness") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(16),
+                        tom = LocalDateTime.now().minusDays(16),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, ARBEID_GJENNOPPTATT),
+                        fom = LocalDateTime.now().minusDays(15),
+                        tom = LocalDateTime.now().minusDays(1),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now(),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 1
+
+                val tilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                tilfelleDuration shouldBeEqualTo 16
+            }
+
+            it("should return 2 Oppfolgingstilfelle, if person is not sick for at least 16 days") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(17),
+                        tom = LocalDateTime.now().minusDays(17),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now().plusDays(1),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 2
+
+                val firstTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                firstTilfelleDuration shouldBeEqualTo 0
+
+                val secondTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.last().start,
+                    oppfolgingstilfelleList.last().end,
+                ).days
+                secondTilfelleDuration shouldBeEqualTo 1
+            }
+
+            it("should return 2 Oppfolgingstilfelle, if person has at least 16 Arbeidsdag between 2 Sykedag") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(17),
+                        tom = LocalDateTime.now().minusDays(17),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, ARBEID_GJENNOPPTATT),
+                        fom = LocalDateTime.now().minusDays(16),
+                        tom = LocalDateTime.now().minusDays(1),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now(),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 2
+
+                val firstTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                firstTilfelleDuration shouldBeEqualTo 0
+
+                val secondTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.last().start,
+                    oppfolgingstilfelleList.last().end,
+                ).days
+                secondTilfelleDuration shouldBeEqualTo 0
+            }
+
+            it("should return 2 Oppfolgingstilfelle, if person has at least 16 Arbeidsdag+Feriedag and at at least 1 Feriedag between 2 Sykedag") {
+                val oppfolgingstilfelleBitList = listOf(
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now().minusDays(20),
+                        tom = LocalDateTime.now().minusDays(20),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, FERIE),
+                        fom = LocalDateTime.now().minusDays(18),
+                        tom = LocalDateTime.now().minusDays(10),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT, PERMISJON),
+                        fom = LocalDateTime.now().minusDays(9),
+                        tom = LocalDateTime.now().minusDays(1),
+                    ),
+                    defaultBit.copy(
+                        createdAt = LocalDateTime.now(),
+                        inntruffet = LocalDateTime.now(),
+                        tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                        fom = LocalDateTime.now(),
+                        tom = LocalDateTime.now(),
+                    ),
+                )
+
+                val oppfolgingstilfelleList = oppfolgingstilfelleService.createOppfolgingstilfelleList(
+                    oppfolgingstilfelleBitList = oppfolgingstilfelleBitList,
+                )
+                oppfolgingstilfelleList.size shouldBeEqualTo 2
+
+                val firstTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.first().start,
+                    oppfolgingstilfelleList.first().end,
+                ).days
+                firstTilfelleDuration shouldBeEqualTo 0
+
+                val secondTilfelleDuration = Period.between(
+                    oppfolgingstilfelleList.last().start,
+                    oppfolgingstilfelleList.last().end,
+                ).days
+                secondTilfelleDuration shouldBeEqualTo 0
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
@@ -11,6 +11,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import testhelper.*
 import testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
 
 class OppfolgingstilfelleApiSpek : Spek({
     val objectMapper: ObjectMapper = configuredJacksonMapper()
@@ -50,7 +51,8 @@ class OppfolgingstilfelleApiSpek : Spek({
 
                             val oppfolgingstilfelleDTO = oppfolgingstilfellePersonDTO.oppfolgingstilfelleList.first()
 
-                            oppfolgingstilfelleDTO.virksomhetsnummerList.size shouldBeEqualTo 0
+                            oppfolgingstilfelleDTO.virksomhetsnummerList.size shouldBeEqualTo 1
+                            oppfolgingstilfelleDTO.virksomhetsnummerList.first() shouldBeEqualTo VIRKSOMHETSNUMMER_DEFAULT.value
                         }
                     }
                 }

--- a/src/test/kotlin/testhelper/UserConstants.kt
+++ b/src/test/kotlin/testhelper/UserConstants.kt
@@ -1,7 +1,10 @@
 package testhelper
 
 import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Virksomhetsnummer
 
 object UserConstants {
     val ARBEIDSTAKER_PERSONIDENTNUMBER = PersonIdentNumber("12345678912")
+
+    val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer("987654321")
 }

--- a/src/test/kotlin/testhelper/generator/OppfolgingstilfelleBitGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/OppfolgingstilfelleBitGenerator.kt
@@ -1,0 +1,22 @@
+package testhelper.generator
+
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.Tag
+import testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+import java.time.LocalDateTime
+import java.util.*
+
+fun generateOppfolgingstilfelleBit() = OppfolgingstilfelleBit(
+    uuid = UUID.randomUUID(),
+    personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
+    virksomhetsnummer = "987654321",
+    createdAt = LocalDateTime.now(),
+    inntruffet = LocalDateTime.now().minusDays(1),
+    fom = LocalDateTime.now().minusDays(1),
+    tom = LocalDateTime.now().plusDays(1),
+    tagList = listOf(
+        Tag.SYKEPENGESOKNAD,
+        Tag.SENDT,
+    ),
+    ressursId = UUID.randomUUID().toString(),
+)


### PR DESCRIPTION
Add logic to take a list of OppfolgingstilfelleBit and group them into a list of Oppfolgingstilfelle based on a set of rules. The list of OppfolgingstilfelleBit create a timeline of days, where each day has a most significant Oppfolgingstilfelle found by using the Tag prioritization. Each day in the timeline is either a Arbeidsdag, Ferie or else a Sykedag.
The days are grouped into a list of Oppfolgingstilfelle based on the ordering of these three types.