### PR TITLE
Avoid issues with SQLTransientConnectionException

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/application/database/Database.kt
@@ -26,7 +26,6 @@ class Database(
             username = config.username
             password = config.password
             maximumPoolSize = config.poolSize
-            minimumIdle = 1
             isAutoCommit = false
             transactionIsolation = "TRANSACTION_REPEATABLE_READ"
             metricsTrackerFactory = PrometheusMetricsTrackerFactory()


### PR DESCRIPTION
The application throws SQLTransientConnectionException due to issues
with too few available connections in connection pool. To avoid this
issue, each successful processing of a relevant Record results in a commit to the database in a single connection that is not reused across records in poll.