### PR TITLE
Reduce memory- and cpu-requirements

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -33,10 +33,10 @@ spec:
     path: /internal/metrics
   resources:
     limits:
-      cpu: 600m
+      cpu: 200m
       memory: 512Mi
     requests:
-      cpu: 500m
+      cpu: 100m
       memory: 384Mi
   ingresses:
     - "https://isoppfolgingstilfelle.dev.intern.nav.no"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -33,11 +33,11 @@ spec:
     path: /internal/metrics
   resources:
     limits:
-      cpu: 1500m
-      memory: 3072Mi
+      cpu: 200m
+      memory: 512Mi
     requests:
-      cpu: 1000m
-      memory: 2048Mi
+      cpu: 100m
+      memory: 384Mi
   ingresses:
     - "https://isoppfolgingstilfelle.intern.nav.no"
   gcp:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/distroless/java17
 WORKDIR /app
 COPY build/libs/app.jar app.jar
-ENV JDK_JAVA_OPTIONS="-Dlogback.configurationFile=logback.xml"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75 -Dlogback.configurationFile=logback.xml"
 ENV TZ="Europe/Oslo"
 EXPOSE 8080
 USER nonroot


### PR DESCRIPTION
Disse parametrene var skrudd høyt fordi det var en stor backlog som skulle prosesseres fra Kafka.