### PR TITLE
Collect all virksomheter into oppfolgingstilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -137,9 +137,11 @@ fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
 }
 
 fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitAndVirksomheter(): Pair<OppfolgingstilfelleBit, List<String>>? {
-    val virksomhetsnummerListe = this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
-    return this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, virksomhetsnummerListe) }
+    return this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, this.getVirksomhetsnummerList()) }
 }
+
+fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerList() =
+    this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
 
 fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitOrNull(): OppfolgingstilfelleBit? {
     TAG_PRIORITY.forEach { tagPriorityElement ->

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -136,9 +136,9 @@ fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
         )
 }
 
-fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitAndVirksomheter(): Pair<OppfolgingstilfelleBit, List<String>>? {
-    return this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, this.getVirksomhetsnummerList()) }
-}
+fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitAndVirksomheter() =
+    this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, this.getVirksomhetsnummerList()) }
+
 
 fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerList() =
     this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -139,7 +139,6 @@ fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
 fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitAndVirksomheter() =
     this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, this.getVirksomhetsnummerList()) }
 
-
 fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerList() =
     this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -118,20 +118,27 @@ fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
         .groupBy { bit -> bit.inntruffet.toLocalDateOslo() }
         .toSortedMap()
         .mapValues { entryDagBitList: Map.Entry<LocalDate, List<OppfolgingstilfelleBit>> ->
-            entryDagBitList.value.findPriorityOppfolgingstilfelleBitOrNull()
+            entryDagBitList.value.findPriorityOppfolgingstilfelleBitAndVirksomheter()
         }
-        .mapNotNull(Map.Entry<LocalDate, OppfolgingstilfelleBit?>::value)
-        .map { bit ->
+        .mapNotNull(Map.Entry<LocalDate, Pair<OppfolgingstilfelleBit, List<String>>?>::value)
+        .map { bitPair ->
             OppfolgingstilfelleDag(
                 dag = dag,
-                priorityOppfolgingstilfelleBit = bit,
+                priorityOppfolgingstilfelleBit = bitPair.first,
+                virksomhetsnummerList = bitPair.second,
             )
         }
         .lastOrNull()
         ?: OppfolgingstilfelleDag(
             dag = dag,
             priorityOppfolgingstilfelleBit = null,
+            virksomhetsnummerList = emptyList(),
         )
+}
+
+fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitAndVirksomheter(): Pair<OppfolgingstilfelleBit, List<String>>? {
+    val virksomhetsnummerListe = this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
+    return this.findPriorityOppfolgingstilfelleBitOrNull()?.let { bit -> Pair(bit, virksomhetsnummerListe) }
 }
 
 fun List<OppfolgingstilfelleBit>.findPriorityOppfolgingstilfelleBitOrNull(): OppfolgingstilfelleBit? {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 class OppfolgingstilfelleDag(
     val dag: LocalDate,
     val priorityOppfolgingstilfelleBit: OppfolgingstilfelleBit?,
+    val virksomhetsnummerList: List<String>,
 )
 
 fun List<OppfolgingstilfelleDag>.groupOppfolgingstilfelleList(): List<Oppfolgingstilfelle> {
@@ -59,9 +60,9 @@ fun List<OppfolgingstilfelleDag>.isArbeidstakerAtTilfelleEnd() =
     }.priorityOppfolgingstilfelleBit?.isArbeidstakerBit() ?: false
 
 fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle(): Oppfolgingstilfelle {
-    val virksomhetsnummerList = this.mapNotNull {
-        it.priorityOppfolgingstilfelleBit?.virksomhetsnummer
-    }.distinct().map { virksomhetsnummer ->
+    val virksomhetsnummerList = this.map {
+        it.virksomhetsnummerList
+    }.flatten().distinct().map { virksomhetsnummer ->
         Virksomhetsnummer(virksomhetsnummer)
     }
     return Oppfolgingstilfelle(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -60,18 +60,20 @@ fun List<OppfolgingstilfelleDag>.isArbeidstakerAtTilfelleEnd() =
     }.priorityOppfolgingstilfelleBit?.isArbeidstakerBit() ?: false
 
 fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle(): Oppfolgingstilfelle {
-    val virksomhetsnummerList = this.map {
-        it.virksomhetsnummerList
-    }.flatten().distinct().map { virksomhetsnummer ->
-        Virksomhetsnummer(virksomhetsnummer)
-    }
     return Oppfolgingstilfelle(
         arbeidstakerAtTilfelleEnd = this.isArbeidstakerAtTilfelleEnd(),
         start = this.first().dag,
         end = this.last().dag,
-        virksomhetsnummerList = virksomhetsnummerList,
+        virksomhetsnummerList = this.toVirksomhetsnummerList(),
     )
 }
+
+fun List<OppfolgingstilfelleDag>.toVirksomhetsnummerList() =
+    this.map {
+        it.virksomhetsnummerList
+    }.flatten().distinct().map { virksomhetsnummer ->
+        Virksomhetsnummer(virksomhetsnummer)
+    }
 
 fun OppfolgingstilfelleDag.isArbeidsdag() =
     priorityOppfolgingstilfelleBit

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -59,14 +59,13 @@ fun List<OppfolgingstilfelleDag>.isArbeidstakerAtTilfelleEnd() =
         it.priorityOppfolgingstilfelleBit != null
     }.priorityOppfolgingstilfelleBit?.isArbeidstakerBit() ?: false
 
-fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle(): Oppfolgingstilfelle {
-    return Oppfolgingstilfelle(
+fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle() =
+    Oppfolgingstilfelle(
         arbeidstakerAtTilfelleEnd = this.isArbeidstakerAtTilfelleEnd(),
         start = this.first().dag,
         end = this.last().dag,
         virksomhetsnummerList = this.toVirksomhetsnummerList(),
     )
-}
 
 fun List<OppfolgingstilfelleDag>.toVirksomhetsnummerList() =
     this.map {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -55,6 +55,36 @@ class OppfolgingstilfelleBitSpek : Spek({
             tilfelleDuration shouldBeEqualTo 16
         }
 
+        it("should return 1 Oppfolgingstilfelle with two virksomheter if biter from different virksomheter") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now(),
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now(),
+                    virksomhetsnummer = "987654320",
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 1
+
+            val tilfelleDuration = Period.between(
+                oppfolgingstilfelleList.first().start,
+                oppfolgingstilfelleList.first().end,
+            ).days
+            tilfelleDuration shouldBeEqualTo 16
+            oppfolgingstilfelleList.first().virksomhetsnummerList.size shouldBeEqualTo 2
+        }
+
         it("should return 1 Oppfolgingstilfelle, if person only has Ferie/Permisjon between 2 Sykedag") {
             val oppfolgingstilfelleBitList = listOf(
                 defaultBit.copy(


### PR DESCRIPTION
Slik det har vært til nå har oppfølgingstilfeller ikke inkludert alle relevante virksomheter. Konsekvensen av det er en potensielt ufullstendig liste over mulige virksomheter når man skal kalle inn til dialogmøte. I tillegg kan det være umulig for nærmeste leder å svare på møtebehov. Begge deler bør løse seg ved endringen i denne PR'en.