### PR TITLE
Cronjob tilfelle

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -76,7 +76,7 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: TOGGLE_KAFKA_SYKETILFELLEBIT_PROCESSING_ENABLED
+    - name: TOGGLE_CRONJOB_SYKETILFELLEBIT_PROCESSING_ENABLED
       value: "true"
     - name: PDL_CLIENT_ID
       value: "dev-fss.pdl.pdl-api"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -76,8 +76,8 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
-    - name: TOGGLE_KAFKA_SYKETILFELLEBIT_PROCESSING_ENABLED
-      value: "true"
+    - name: TOGGLE_CRONJOB_SYKETILFELLEBIT_PROCESSING_ENABLED
+      value: "false"
     - name: PDL_CLIENT_ID
       value: "prod-fss.pdl.pdl-api"
     - name: PDL_URL

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -43,7 +43,7 @@ data class Environment(
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
     ),
 
-    val kafkaSyketilfellebitProcessingEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_SYKETILFELLEBIT_PROCESSING_ENABLED").toBoolean(),
+    val cronjobSyketilfellebitProcessingEnabled: Boolean = getEnvVar("TOGGLE_CRONJOB_SYKETILFELLEBIT_PROCESSING_ENABLED").toBoolean(),
 
     val redis: RedisEnvironment = RedisEnvironment(
         host = getEnvVar("REDIS_HOST"),
@@ -65,6 +65,7 @@ data class Environment(
             clientId = getEnvVar("NARMESTELEDER_CLIENT_ID")
         )
     ),
+    val electorPath: String = getEnvVar("ELECTOR_PATH"),
     private val isdialogmoteApplicationName: String = "isdialogmote",
     val systemAPIAuthorizedConsumerApplicationNames: List<String> = listOf(
         isdialogmoteApplicationName,

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/Cronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/Cronjob.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.application.cronjob
+
+interface Cronjob {
+    suspend fun run()
+    val initialDelayMinutes: Long
+    val intervalDelayMinutes: Long
+}

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.application.cronjob
+
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.Environment
+import no.nav.syfo.application.backgroundtask.launchBackgroundTask
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
+import no.nav.syfo.client.leaderelection.LeaderPodClient
+import no.nav.syfo.oppfolgingstilfelle.bit.cronjob.OppfolgingstilfelleCronjob
+
+fun launchCronjobModule(
+    applicationState: ApplicationState,
+    environment: Environment,
+    database: DatabaseInterface,
+    oppfolgingstilfellePersonService: OppfolgingstilfellePersonService,
+) {
+    val leaderPodClient = LeaderPodClient(
+        electorPath = environment.electorPath
+    )
+    val cronjobRunner = CronjobRunner(
+        applicationState = applicationState,
+        leaderPodClient = leaderPodClient
+    )
+    val oppfolgingstilfelleCronjob = OppfolgingstilfelleCronjob(
+        database = database,
+        oppfolgingstilfellePersonService = oppfolgingstilfellePersonService,
+    )
+
+    if (environment.cronjobSyketilfellebitProcessingEnabled) {
+        launchBackgroundTask(
+            applicationState = applicationState,
+        ) {
+            cronjobRunner.start(
+                cronjob = oppfolgingstilfelleCronjob,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobResult.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobResult.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.application.cronjob
+
+data class CronjobResult(
+    var updated: Int = 0,
+    var failed: Int = 0
+)

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobRunner.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobRunner.kt
@@ -1,0 +1,53 @@
+package no.nav.syfo.application.cronjob
+
+import kotlinx.coroutines.*
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.client.leaderelection.LeaderPodClient
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class CronjobRunner(
+    private val applicationState: ApplicationState,
+    private val leaderPodClient: LeaderPodClient,
+) {
+
+    private val log = LoggerFactory.getLogger(CronjobRunner::class.java)
+
+    suspend fun start(cronjob: Cronjob) = coroutineScope {
+        val cronjobName = cronjob.javaClass.simpleName
+        val (initialDelay, intervalDelay) = delays(cronjob)
+        log.info(
+            "Scheduling start of $cronjobName: {} ms, {} ms",
+            StructuredArguments.keyValue("initialDelay", initialDelay),
+            StructuredArguments.keyValue("intervalDelay", intervalDelay),
+        )
+        delay(initialDelay)
+
+        while (applicationState.ready) {
+            val job = launch {
+                try {
+                    if (leaderPodClient.isLeader()) {
+                        cronjob.run()
+                    } else {
+                        log.info("Pod is not leader and will not perform cronjob")
+                    }
+                } catch (ex: Exception) {
+                    log.error("Exception in $cronjobName. Job will run again after delay.", ex)
+                }
+            }
+            delay(intervalDelay)
+            if (job.isActive) {
+                log.info("Waiting for job to finish")
+                job.join()
+            }
+        }
+        log.info("Ending $cronjobName due to failed liveness check ")
+    }
+
+    private fun delays(cronjob: Cronjob): Pair<Long, Long> {
+        val initialDelay = Duration.ofMinutes(cronjob.initialDelayMinutes).toMillis()
+        val intervalDelay = Duration.ofMinutes(cronjob.intervalDelayMinutes).toMillis()
+        return Pair(initialDelay, intervalDelay)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.client
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.apache.*
-import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.jackson.*
@@ -34,7 +33,7 @@ val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
 }
 
 fun httpClientDefault() = HttpClient(
-    engineFactory = CIO,
+    engineFactory = Apache,
     block = commonConfig,
 )
 

--- a/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodClient.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.client.leaderelection
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.apache.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -15,7 +15,7 @@ import java.net.InetAddress
 class LeaderPodClient(
     private val electorPath: String,
 ) {
-    private val httpClient = HttpClient(CIO) {
+    private val httpClient = HttpClient(Apache) {
         expectSuccess = true
     }
 

--- a/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodClient.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.client.leaderelection
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.util.configuredJacksonMapper
+import org.slf4j.LoggerFactory
+import java.net.InetAddress
+
+class LeaderPodClient(
+    private val electorPath: String,
+) {
+    private val httpClient = HttpClient(CIO) {
+        expectSuccess = true
+    }
+
+    private val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    fun isLeader(): Boolean {
+        try {
+            val electorUrl = getElectorUrl(electorPath)
+            log.debug("Looking for leader at url=$electorUrl")
+            return runBlocking {
+                val response: HttpResponse = httpClient.get(electorUrl) {
+                    accept(ContentType.Text.Plain)
+                }
+                val leaderPodDTO: LeaderPodDTO = objectMapper.readValue(
+                    response.bodyAsText()
+                )
+                val hostname: String = InetAddress.getLocalHost().hostName
+
+                if (hostname == leaderPodDTO.name) {
+                    log.debug("Pod with $hostname is the leader")
+                    true
+                } else {
+                    log.debug("Pod with $hostname is not leader, leader is:${leaderPodDTO.name}")
+                    false
+                }
+            }
+        } catch (ex: Exception) {
+            log.error("Exception caught while looking for leader.", ex)
+            return false
+        }
+    }
+
+    private fun getElectorUrl(electorPath: String) = "http://$electorPath"
+
+    companion object {
+        private val log = LoggerFactory.getLogger(LeaderPodClient::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/client/leaderelection/LeaderPodDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.client.leaderelection
+
+data class LeaderPodDTO(
+    val name: String,
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitService.kt
@@ -19,7 +19,7 @@ class OppfolgingstilfelleBitService(
     fun oppfolgingstilfelleBitList(
         personIdentNumber: PersonIdentNumber,
     ) = database.connection.use { connection ->
-        connection.getOppfolgingstilfelleBitList(
+        connection.getProcessedOppfolgingstilfelleBitList(
             personIdentNumber = personIdentNumber,
         ).toOppfolgingstilfelleBitList()
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/cronjob/OppfolgingstilfelleCronjob.kt
@@ -30,7 +30,7 @@ class OppfolgingstilfelleCronjob(
         unprocessed.forEach { oppfolgingstilfelleBit ->
             try {
                 database.connection.use { connection ->
-                    val oppfolgingstilfelleBitForPersonList = connection.getOppfolgingstilfelleBitList(
+                    val oppfolgingstilfelleBitForPersonList = connection.getProcessedOppfolgingstilfelleBitList(
                         personIdentNumber = oppfolgingstilfelleBit.personIdentNumber,
                     ).toOppfolgingstilfelleBitList().toMutableList()
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/cronjob/OppfolgingstilfelleCronjob.kt
@@ -1,0 +1,58 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.cronjob
+
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.application.cronjob.Cronjob
+import no.nav.syfo.application.cronjob.CronjobResult
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.oppfolgingstilfelle.bit.database.*
+import no.nav.syfo.oppfolgingstilfelle.bit.database.domain.toOppfolgingstilfelleBitList
+import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
+import org.slf4j.LoggerFactory
+
+class OppfolgingstilfelleCronjob(
+    private val database: DatabaseInterface,
+    private val oppfolgingstilfellePersonService: OppfolgingstilfellePersonService,
+) : Cronjob {
+    override val initialDelayMinutes: Long = 2
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run() {
+        val result = runJob()
+        log.info(
+            "Completed tilfellebit processing job with result: {}, {}",
+            StructuredArguments.keyValue("failed", result.failed),
+            StructuredArguments.keyValue("updated", result.updated),
+        )
+    }
+
+    fun runJob() = CronjobResult().also { result ->
+        val unprocessed = database.getUnprocessedOppfolgingstilfelleBitList().toOppfolgingstilfelleBitList()
+        unprocessed.forEach { oppfolgingstilfelleBit ->
+            try {
+                database.connection.use { connection ->
+                    val oppfolgingstilfelleBitForPersonList = connection.getOppfolgingstilfelleBitList(
+                        personIdentNumber = oppfolgingstilfelleBit.personIdentNumber,
+                    ).toOppfolgingstilfelleBitList().toMutableList()
+
+                    oppfolgingstilfelleBitForPersonList.add(0, oppfolgingstilfelleBit)
+
+                    oppfolgingstilfellePersonService.createOppfolgingstilfellePerson(
+                        connection = connection,
+                        oppfolgingstilfelleBit = oppfolgingstilfelleBit,
+                        oppfolgingstilfelleBitForPersonList = oppfolgingstilfelleBitForPersonList,
+                    )
+                    connection.setProcessedOppfolgingstilfelleBit(oppfolgingstilfelleBit.uuid)
+                    connection.commit()
+                }
+                result.updated++
+            } catch (exc: Exception) {
+                log.error("caught exception when processing oppfolgingstilfelleBit", exc)
+                result.failed++
+            }
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(OppfolgingstilfelleCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/database/OppfolgingstilfelleBitQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/database/OppfolgingstilfelleBitQuery.kt
@@ -74,18 +74,18 @@ fun Connection.getOppfolgingstilfelleBitForUUID(
     }
 }.firstOrNull()
 
-const val queryGetOppfolgingstilfelleBitList =
+const val queryGetProcessedOppfolgingstilfelleBitList =
     """
     SELECT *
     FROM TILFELLE_BIT
     WHERE personident = ? AND processed
-    ORDER BY inntruffet DESC;
+    ORDER BY inntruffet DESC, id DESC;
     """
 
-fun Connection.getOppfolgingstilfelleBitList(
+fun Connection.getProcessedOppfolgingstilfelleBitList(
     personIdentNumber: PersonIdentNumber,
 ): List<POppfolgingstilfelleBit> =
-    this.prepareStatement(queryGetOppfolgingstilfelleBitList).use {
+    this.prepareStatement(queryGetProcessedOppfolgingstilfelleBitList).use {
         it.setString(1, personIdentNumber.value)
         it.executeQuery().toList {
             toPOppfolgingstilfelleBit()

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -147,7 +147,7 @@ fun OppfolgingstilfelleBit.tagsToString() = this.tagList.joinToString(",")
 
 fun String.toTagList(): List<Tag> = split(',').map(String::trim).map(Tag::valueOf)
 
-fun KafkaSyketilfellebit.toOppfolgingstilfelleBit(): OppfolgingstilfelleBit {
+fun KafkaSyketilfellebit.toOppfolgingstilfelleBit(cronjobEnabled: Boolean): OppfolgingstilfelleBit {
     return OppfolgingstilfelleBit(
         uuid = UUID.fromString(this.id),
         personIdentNumber = PersonIdentNumber(this.fnr),
@@ -158,6 +158,7 @@ fun KafkaSyketilfellebit.toOppfolgingstilfelleBit(): OppfolgingstilfelleBit {
         ressursId = this.ressursId,
         fom = this.fom,
         tom = this.tom,
+        processed = !cronjobEnabled,
     )
 }
 

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaSyketilfellebitService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaSyketilfellebitService.kt
@@ -11,6 +11,7 @@ import java.time.Duration
 class KafkaSyketilfellebitService(
     val database: DatabaseInterface,
     val oppfolgingstilfelleBitService: OppfolgingstilfelleBitService,
+    val cronjobEnabled: Boolean,
 ) {
     fun pollAndProcessRecords(
         kafkaConsumerSyketilfelleBit: KafkaConsumer<String, KafkaSyketilfellebit>,
@@ -66,11 +67,12 @@ class KafkaSyketilfellebitService(
         relevantRecordList: List<ConsumerRecord<String, KafkaSyketilfellebit>>,
     ) {
         val relevantOppfolgingstilfelleBitList = relevantRecordList.map {
-            it.value().toOppfolgingstilfelleBit()
+            it.value().toOppfolgingstilfelleBit(cronjobEnabled)
         }
         oppfolgingstilfelleBitService.createOppfolgingstilfelleBitList(
             connection = connection,
             oppfolgingstilfelleBitList = relevantOppfolgingstilfelleBitList,
+            cronjobEnabled = cronjobEnabled,
         )
     }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
@@ -56,6 +56,7 @@ class OppfolgingstilfelleApiSpek : Spek({
         val kafkaSyketilfellebitService = KafkaSyketilfellebitService(
             database = database,
             oppfolgingstilfelleBitService = oppfolgingstilfelleBitService,
+            cronjobEnabled = externalMockEnvironment.environment.cronjobSyketilfellebitProcessingEnabled,
         )
         val personIdentDefault = PERSONIDENTNUMBER_DEFAULT.toHistoricalPersonIdentNumber()
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiSpek.kt
@@ -55,6 +55,7 @@ class OppfolgingstilfelleSystemApiSpek : Spek({
         val kafkaSyketilfellebitService = KafkaSyketilfellebitService(
             database = database,
             oppfolgingstilfelleBitService = oppfolgingstilfelleBitService,
+            cronjobEnabled = externalMockEnvironment.environment.cronjobSyketilfellebitProcessingEnabled,
         )
         val personIdentDefault = PERSONIDENTNUMBER_DEFAULT.toHistoricalPersonIdentNumber()
 

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -48,7 +48,7 @@ fun testEnvironment(
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = "truststore",
     ),
-    kafkaSyketilfellebitProcessingEnabled = true,
+    cronjobSyketilfellebitProcessingEnabled = false,
     clients = ClientsEnvironment(
         pdl = ClientEnvironment(
             baseUrl = pdlUrl,

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -63,6 +63,7 @@ fun testEnvironment(
             clientId = "narmestelederClientId",
         )
     ),
+    electorPath = "electorPath",
     redis = RedisEnvironment(
         host = "localhost",
         port = 6379,


### PR DESCRIPTION
Definerer ny cronjob som skal lage oppfolgingstilfeller i stedet for at disse lages med det samme man leser tilfellebitene fra Kafka. Togglet ut i første omgang i produksjon, skal teste at det oppfører seg som forventet på dev-gcp.

Skriver om testene i neste PR (slik at det er det som skjer i cronjob'en som testes i stedet for prosesseringen fra Kafka som blir mye enklere når cronjob'en tar over).