### PR TITLE
Bugfix tilfellebit-prioritering

### DIFF
--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -145,13 +145,15 @@ class OppfolgingstilfelleBitSpek : Spek({
 
             val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
             oppfolgingstilfelleList.size shouldBeEqualTo 1
+            val oppfolgingstilfelle = oppfolgingstilfelleList.first()
 
             val tilfelleDuration = Period.between(
-                oppfolgingstilfelleList.first().start,
-                oppfolgingstilfelleList.first().end,
+                oppfolgingstilfelle.start,
+                oppfolgingstilfelle.end,
             ).days
             tilfelleDuration shouldBeEqualTo 16
-            oppfolgingstilfelleList.first().virksomhetsnummerList.size shouldBeEqualTo 2
+            oppfolgingstilfelle.virksomhetsnummerList.size shouldBeEqualTo 2
+            oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
         }
 
         it("should return 1 Oppfolgingstilfelle with two virksomheter if biter from different virksomheter and both sykmelding and sykepengesoknad") {
@@ -166,9 +168,9 @@ class OppfolgingstilfelleBitSpek : Spek({
                 ),
                 defaultBit.copy(
                     createdAt = nowUTC(),
-                    inntruffet = nowUTC().minusDays(1),
+                    inntruffet = nowUTC().minusDays(8),
                     tagList = listOf(SYKEPENGESOKNAD, SENDT),
-                    fom = LocalDate.now().minusDays(10),
+                    fom = LocalDate.now().minusDays(16),
                     tom = LocalDate.now().minusDays(8),
                 ),
                 defaultBit.copy(
@@ -176,20 +178,22 @@ class OppfolgingstilfelleBitSpek : Spek({
                     inntruffet = nowUTC().minusDays(1),
                     tagList = listOf(SYKEPENGESOKNAD, SENDT),
                     fom = LocalDate.now().minusDays(7),
-                    tom = LocalDate.now().minusDays(2),
+                    tom = LocalDate.now(),
                     virksomhetsnummer = "987654320",
                 ),
             )
 
             val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
             oppfolgingstilfelleList.size shouldBeEqualTo 1
+            val oppfolgingstilfelle = oppfolgingstilfelleList.first()
 
             val tilfelleDuration = Period.between(
-                oppfolgingstilfelleList.first().start,
-                oppfolgingstilfelleList.first().end,
+                oppfolgingstilfelle.start,
+                oppfolgingstilfelle.end,
             ).days
             tilfelleDuration shouldBeEqualTo 16
-            oppfolgingstilfelleList.first().virksomhetsnummerList.size shouldBeEqualTo 2
+            oppfolgingstilfelle.virksomhetsnummerList.size shouldBeEqualTo 2
+            oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
         }
 
         it("should return 1 Oppfolgingstilfelle, if person only has Ferie/Permisjon between 2 Sykedag") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -154,6 +154,44 @@ class OppfolgingstilfelleBitSpek : Spek({
             oppfolgingstilfelleList.first().virksomhetsnummerList.size shouldBeEqualTo 2
         }
 
+        it("should return 1 Oppfolgingstilfelle with two virksomheter if biter from different virksomheter and both sykmelding and sykepengesoknad") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, BEKREFTET, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now(),
+                    virksomhetsnummer = null,
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC().minusDays(1),
+                    tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                    fom = LocalDate.now().minusDays(10),
+                    tom = LocalDate.now().minusDays(8),
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC().minusDays(1),
+                    tagList = listOf(SYKEPENGESOKNAD, SENDT),
+                    fom = LocalDate.now().minusDays(7),
+                    tom = LocalDate.now().minusDays(2),
+                    virksomhetsnummer = "987654320",
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 1
+
+            val tilfelleDuration = Period.between(
+                oppfolgingstilfelleList.first().start,
+                oppfolgingstilfelleList.first().end,
+            ).days
+            tilfelleDuration shouldBeEqualTo 16
+            oppfolgingstilfelleList.first().virksomhetsnummerList.size shouldBeEqualTo 2
+        }
+
         it("should return 1 Oppfolgingstilfelle, if person only has Ferie/Permisjon between 2 Sykedag") {
             val oppfolgingstilfelleBitList = listOf(
                 defaultBit.copy(


### PR DESCRIPTION
Vi fikk en jira-sak der ettersendt sykmelding (med manglende virksomhetsnummer) har overstyrt tidligere innkomne søknader (med virksomhetsnummer). Dette kan gjøre at arbeidstakere ikke blir kandidater, samt at innkalling til dialogmøter ikke fungerer så godt.