### PR TITLE
Only use orgnr from sykmelding-ny if necessary

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -133,11 +133,16 @@ fun List<OppfolgingstilfelleBit>.pickOppfolgingstilfelleDag(
     return OppfolgingstilfelleDag(
         dag = dag,
         priorityOppfolgingstilfelleBit = bitListForDag.firstOrNull(),
-        virksomhetsnummerList = bitListForDag.getVirksomhetsnummerList(),
+        virksomhetsnummerPreferred = bitListForDag.getVirksomhetsnummerPreferred(),
+        virksomhetsnummerAll = bitListForDag.getVirksomhetsnummerAll(),
     )
 }
 
-fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerList() =
+fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerPreferred() =
+    this.filter { bit -> !(bit.tagList in (Tag.SYKMELDING and Tag.NY)) }
+        .mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
+
+fun List<OppfolgingstilfelleBit>.getVirksomhetsnummerAll() =
     this.mapNotNull { bit -> bit.virksomhetsnummer }.distinct()
 
 fun List<OppfolgingstilfelleBit>.containsSendtSykmeldingBit(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -9,7 +9,8 @@ import java.time.LocalDate
 class OppfolgingstilfelleDag(
     val dag: LocalDate,
     val priorityOppfolgingstilfelleBit: OppfolgingstilfelleBit?,
-    val virksomhetsnummerList: List<String>,
+    val virksomhetsnummerPreferred: List<String>,
+    val virksomhetsnummerAll: List<String>,
 )
 
 fun List<OppfolgingstilfelleDag>.groupOppfolgingstilfelleList(): List<Oppfolgingstilfelle> {
@@ -62,20 +63,27 @@ fun List<OppfolgingstilfelleDag>.isArbeidstakerAtTilfelleEnd() =
 fun List<OppfolgingstilfelleDag>.gradertAtTilfelleEnd() =
     this.last {
         it.priorityOppfolgingstilfelleBit != null
-    }.isGradert() ?: false
+    }.isGradert()
 
 fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle() =
     Oppfolgingstilfelle(
         arbeidstakerAtTilfelleEnd = this.isArbeidstakerAtTilfelleEnd(),
         start = this.first().dag,
         end = this.last().dag,
-        virksomhetsnummerList = this.toVirksomhetsnummerList(),
+        virksomhetsnummerList = this.toVirksomhetsnummerPreferred().ifEmpty { this.toVirksomhetsnummerAll() },
         gradertAtTilfelleEnd = this.gradertAtTilfelleEnd(),
     )
 
-fun List<OppfolgingstilfelleDag>.toVirksomhetsnummerList() =
+fun List<OppfolgingstilfelleDag>.toVirksomhetsnummerPreferred() =
     this.map {
-        it.virksomhetsnummerList
+        it.virksomhetsnummerPreferred
+    }.flatten().distinct().map { virksomhetsnummer ->
+        Virksomhetsnummer(virksomhetsnummer)
+    }
+
+fun List<OppfolgingstilfelleDag>.toVirksomhetsnummerAll() =
+    this.map {
+        it.virksomhetsnummerAll
     }.flatten().distinct().map { virksomhetsnummer ->
         Virksomhetsnummer(virksomhetsnummer)
     }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -265,6 +265,73 @@ class OppfolgingstilfelleBitSpek : Spek({
             oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
         }
 
+        it("should return 1 Oppfolgingstilfelle with virksomhet from sendt bit when both sykmelding and sykmelding-ny") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, NY, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now(),
+                    virksomhetsnummer = "987654320",
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, SENDT, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now(),
+                    virksomhetsnummer = "987654330",
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 1
+            val oppfolgingstilfelle = oppfolgingstilfelleList.first()
+
+            val tilfelleDuration = Period.between(
+                oppfolgingstilfelle.start,
+                oppfolgingstilfelle.end,
+            ).days
+            tilfelleDuration shouldBeEqualTo 16
+            oppfolgingstilfelle.virksomhetsnummerList.size shouldBeEqualTo 1
+            oppfolgingstilfelle.virksomhetsnummerList[0].value shouldBeEqualTo "987654330"
+            oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
+        }
+
+        it("should return 1 Oppfolgingstilfelle with virksomhet from both biter when both only sykmelding-ny") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, NY, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(16),
+                    tom = LocalDate.now().minusDays(7),
+                    virksomhetsnummer = "987654320",
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, NY, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(6),
+                    tom = LocalDate.now(),
+                    virksomhetsnummer = "987654330",
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 1
+            val oppfolgingstilfelle = oppfolgingstilfelleList.first()
+
+            val tilfelleDuration = Period.between(
+                oppfolgingstilfelle.start,
+                oppfolgingstilfelle.end,
+            ).days
+            tilfelleDuration shouldBeEqualTo 16
+            oppfolgingstilfelle.virksomhetsnummerList.size shouldBeEqualTo 2
+            oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
+        }
+
         it("should return 1 Oppfolgingstilfelle, if person only has Ferie/Permisjon between 2 Sykedag") {
             val oppfolgingstilfelleBitList = listOf(
                 defaultBit.copy(


### PR DESCRIPTION
Dette gjør at virksomhetsnumrene på oppfølgingstilfellet blir de arbeidstakeren har valgt ved innsending. Men hvis den lista blir tom bruker vi også de som vi har hentet fra aareg for sykmelding-ny-biter.