### PR TITLE
Use inntektsmelding

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -69,6 +69,7 @@ data class OppfolgingstilfelleBit(
             Tag.SYKEPENGESOKNAD and Tag.SENDT and ListContainsPredicate.tagsSize(2),
             Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.BEHANDLINGSDAG,
             Tag.SYKEPENGESOKNAD and Tag.SENDT and Tag.BEHANDLINGSDAGER,
+            Tag.INNTEKTSMELDING and Tag.ARBEIDSGIVERPERIODE,
             Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and Tag.BEHANDLINGSDAGER,
             Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and Tag.FULL_AKTIVITET,
             Tag.SYKMELDING and (Tag.SENDT or Tag.BEKREFTET) and Tag.PERIODE and (Tag.GRADERT_AKTIVITET or Tag.INGEN_AKTIVITET),

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaConfig.kt
@@ -12,7 +12,7 @@ fun kafkaSyketilfelleBitConsumerConfig(
     return Properties().apply {
         putAll(commonKafkaAivenConfig(kafkaEnvironment))
 
-        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v1"
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v2"
         this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
             KafkaSyketilfellebitDeserializer::class.java.canonicalName

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaConfig.kt
@@ -12,7 +12,7 @@ fun kafkaSyketilfelleBitConsumerConfig(
     return Properties().apply {
         putAll(commonKafkaAivenConfig(kafkaEnvironment))
 
-        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v2"
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v1"
         this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
             KafkaSyketilfellebitDeserializer::class.java.canonicalName

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaSyketilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/KafkaSyketilfellebit.kt
@@ -21,6 +21,6 @@ data class KafkaSyketilfellebit(
 fun KafkaSyketilfellebit.isRelevantForOppfolgingstilfelle(
     lesSykmeldingNy: Boolean,
 ): Boolean =
-    (this.orgnummer != null && !this.tags.contains(Tag.INNTEKTSMELDING.name)) ||
+    (this.orgnummer != null) ||
         this.tags.containsAll(listOf(Tag.SYKMELDING.name, Tag.BEKREFTET.name)) ||
         (lesSykmeldingNy && this.tags.containsAll(listOf(Tag.SYKMELDING.name, Tag.NY.name)))


### PR DESCRIPTION
Dette gjør at tilfellebiter med tag inntektsmelding inngår i det som brukes for å lage oppfølgingstilfeller. Dagene regnes som sykedager, og virksomhetsnummeret blir med i lista over orgnr til oppfølgingstilfellet - dette er vesentlig når vi får oppfølgingstilfeller basert på sykmelding-ny siden vi da bare har orgnr hentet fra aareg.

