### PR TITLE
Log sykmelding ny

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -78,8 +78,8 @@ fun List<OppfolgingstilfelleDag>.toOppfolgingstilfelle(): Oppfolgingstilfelle {
             ?: false
     }
     if (onlySykmeldingNyOrInntektsmelding && this.durationDays() > 118) {
-        val sampleUUID = this.mapNotNull { dag -> dag.priorityOppfolgingstilfelleBit}.firstOrNull()?.uuid
-        log.info("Created oppfolgingstilfelle with duration>118 days based on only sykmelding-ny, bit sample uuid: ${sampleUUID}")
+        val sampleUUID = this.mapNotNull { dag -> dag.priorityOppfolgingstilfelleBit }.firstOrNull()?.uuid
+        log.info("Created oppfolgingstilfelle with duration>118 days based on only sykmelding-ny, bit sample uuid: $sampleUUID")
         SYKMELDING_NY_COUNTER.increment()
     }
     return Oppfolgingstilfelle(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/metric/OppfolgingstilfelleMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/metric/OppfolgingstilfelleMetric.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.oppfolgingstilfelle.person.metric
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.application.metric.METRICS_NS
+import no.nav.syfo.application.metric.METRICS_REGISTRY
+
+const val SYKMELDING_NY_COUNTER_NAME = "${METRICS_NS}_oppfolgingstilfelle_sykmelding_ny"
+
+
+val SYKMELDING_NY_COUNTER: Counter = Counter.builder(SYKMELDING_NY_COUNTER_NAME)
+    .description("Counts the number of oppfolgingstilfeller > 118 days created only from sykmelding-ny")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/metric/OppfolgingstilfelleMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/metric/OppfolgingstilfelleMetric.kt
@@ -5,7 +5,6 @@ import no.nav.syfo.application.metric.METRICS_REGISTRY
 
 const val SYKMELDING_NY_COUNTER_NAME = "${METRICS_NS}_oppfolgingstilfelle_sykmelding_ny"
 
-
 val SYKMELDING_NY_COUNTER: Counter = Counter.builder(SYKMELDING_NY_COUNTER_NAME)
     .description("Counts the number of oppfolgingstilfeller > 118 days created only from sykmelding-ny")
     .register(METRICS_REGISTRY)


### PR DESCRIPTION
Telle opp og logge info om de oppfølgingstilfellene som opprettes som bare er basert på sykmelding-ny (+ inntektsmelding).

