### PR TITLE
Grant access to api from isdialogmotekandidat

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -52,6 +52,9 @@ spec:
         - application: isdialogmote
           namespace: teamsykefravr
           cluster: dev-gcp
+        - application: isdialogmotekandidat
+          namespace: teamsykefravr
+          cluster: dev-gcp
         - application: syfomodiaperson
           namespace: teamsykefravr
           cluster: dev-fss

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -52,6 +52,9 @@ spec:
         - application: isdialogmote
           namespace: teamsykefravr
           cluster: prod-gcp
+        - application: isdialogmotekandidat
+          namespace: teamsykefravr
+          cluster: prod-gcp
         - application: syfomodiaperson
           namespace: teamsykefravr
           cluster: prod-fss


### PR DESCRIPTION
Tenker å hente siste oppfølgingstilfelle via api i stedet for å bruke det som lagres i isdialogmotekandidat.