### PR TITLE
Korrigerer sykmelding med feil tom

### DIFF
--- a/src/main/resources/db/migration/V2_2__korriger_sykmelding.sql
+++ b/src/main/resources/db/migration/V2_2__korriger_sykmelding.sql
@@ -1,0 +1,2 @@
+UPDATE TILFELLE_BIT SET tom='2022-03-18' where uuid='a61dde5b-8350-4116-9a13-07c837a8ab46';
+UPDATE TILFELLE_BIT SET processed=false where uuid='454b4846-48c6-43b4-a4d9-83c9f917a6bf';


### PR DESCRIPTION
Korrigerer tom for en sykmelding-bit som var blitt feil (slik at arbeidstaker får et mye lengre oppfølgingstilfelle enn det det faktisk er). Setter processed=false på den siste tilfelle-biten for den aktuelle personen for å trigge generering av et nytt og korrigert oppfølgingstilfelle.