### PR TITLE
Consumer for personhendelser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
     kotlin("jvm") version "1.7.0"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
+    id("com.github.davidmc24.gradle.plugin.avro") version "1.5.0"
 }
 
 val githubUser: String by project
@@ -139,6 +140,7 @@ tasks {
     }
 
     withType<KotlinCompile> {
+        dependsOn(":generateAvroJava")
         kotlinOptions.jvmTarget = "17"
     }
 

--- a/src/main/avro/Personhendelse.avdl
+++ b/src/main/avro/Personhendelse.avdl
@@ -1,0 +1,25 @@
+@namespace("no.nav.person.pdl.leesah")
+protocol PersonhendelseProto {
+	import idl "doedsfall/Doedsfall.avdl";
+
+	enum Endringstype {
+		OPPRETTET,
+		KORRIGERT,
+		ANNULLERT,
+		OPPHOERT
+	}
+
+	record Personhendelse {
+		string hendelseId;
+		array<string> personidenter;
+
+		string master;
+		timestamp_ms opprettet;
+
+		string opplysningstype;
+		Endringstype endringstype;
+		union { null, string } tidligereHendelseId = null; // Peker til tidligere hendelse ved korrigering og annullering.
+
+		union { null, no.nav.person.pdl.leesah.doedsfall.Doedsfall } doedsfall = null;
+	}
+}

--- a/src/main/avro/doedsfall/Doedsfall.avdl
+++ b/src/main/avro/doedsfall/Doedsfall.avdl
@@ -1,0 +1,7 @@
+@namespace("no.nav.person.pdl.leesah.doedsfall")
+protocol DoedsfallV1 {
+
+	record Doedsfall {
+		union { null, date } doedsdato = null;
+	}
+}

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -24,6 +24,7 @@ import no.nav.syfo.identhendelse.kafka.IdenthendelseConsumerService
 import no.nav.syfo.identhendelse.kafka.launchKafkaTaskIdenthendelse
 import no.nav.syfo.oppfolgingstilfelle.person.kafka.OppfolgingstilfellePersonProducer
 import no.nav.syfo.oppfolgingstilfelle.person.kafka.kafkaOppfolgingstilfelleProducerConfig
+import no.nav.syfo.personhendelse.kafka.launchKafkaTaskPersonhendelse
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
@@ -121,6 +122,12 @@ fun main() {
                 kafkaIdenthendelseConsumerService = kafkaIdenthendelseConsumerService,
             )
         }
+        launchKafkaTaskPersonhendelse(
+            applicationState = applicationState,
+            kafkaEnvironment = environment.kafka,
+            database = applicationDatabase,
+            pdlClient = pdlClient,
+        )
         launchCronjobModule(
             applicationState = applicationState,
             environment = environment,

--- a/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
@@ -5,10 +5,11 @@ import no.nav.person.pdl.leesah.Personhendelse
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
-import no.nav.syfo.personhendelse.db.addPerson
+import no.nav.syfo.personhendelse.db.createPerson
 import no.nav.syfo.personhendelse.db.getDodsdato
 import no.nav.syfo.util.kafkaCallId
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class PersonhendelseService(
     private val database: DatabaseInterface,
@@ -20,11 +21,7 @@ class PersonhendelseService(
             personhendelse.personidenter
                 .mapNotNull { personIdent ->
                     try {
-                        if (personIdent.isNullOrEmpty() || personIdent.length != 11) {
-                            null
-                        } else {
-                            PersonIdentNumber(personIdent)
-                        }
+                        PersonIdentNumber(personIdent)
                     } catch (ex: IllegalArgumentException) {
                         log.warn("Invalid personident for Personhendelse", ex)
                         null
@@ -34,8 +31,8 @@ class PersonhendelseService(
                     if (isKnownPersonIdent(personIdent)) {
                         database.connection.use { connection ->
                             if (connection.getDodsdato(personIdent) == null) {
-                                connection.addPerson(
-                                    uuid = personhendelse.hendelseId,
+                                connection.createPerson(
+                                    uuid = UUID.fromString(personhendelse.hendelseId),
                                     personIdent = personIdent,
                                     dodsdato = personhendelse.doedsfall.doedsdato,
                                 )

--- a/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
@@ -21,7 +21,12 @@ class PersonhendelseService(
             personhendelse.personidenter
                 .mapNotNull { personIdent ->
                     try {
-                        PersonIdentNumber(personIdent)
+                        if (personIdent.isNullOrEmpty() || personIdent.length == 13) {
+                            // ikke lag warning for aktoerid'er
+                            null
+                        } else {
+                            PersonIdentNumber(personIdent)
+                        }
                     } catch (ex: IllegalArgumentException) {
                         log.warn("Invalid personident for Personhendelse", ex)
                         null

--- a/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/PersonhendelseService.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.personhendelse
+
+import no.nav.person.pdl.leesah.Endringstype
+import no.nav.person.pdl.leesah.Personhendelse
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.personhendelse.db.addPerson
+import no.nav.syfo.personhendelse.db.getDodsdato
+import no.nav.syfo.util.kafkaCallId
+import org.slf4j.LoggerFactory
+
+class PersonhendelseService(
+    private val database: DatabaseInterface,
+    private val oppfolgingstilfelleService: OppfolgingstilfelleService,
+) {
+    suspend fun handlePersonhendelse(personhendelse: Personhendelse) {
+        if (personhendelse.doedsfall != null && personhendelse.endringstype == Endringstype.OPPRETTET) {
+            log.info("Received personhendelse: Hendelseid: ${personhendelse.hendelseId}, Endringstype: ${personhendelse.endringstype.name}, Oppltype: ${personhendelse.opplysningstype}, Dato: ${personhendelse.doedsfall?.doedsdato}")
+            personhendelse.personidenter
+                .mapNotNull { personIdent ->
+                    try {
+                        if (personIdent.isNullOrEmpty() || personIdent.length != 11) {
+                            null
+                        } else {
+                            PersonIdentNumber(personIdent)
+                        }
+                    } catch (ex: IllegalArgumentException) {
+                        log.warn("Invalid personident for Personhendelse", ex)
+                        null
+                    }
+                }
+                .forEach { personIdent ->
+                    if (isKnownPersonIdent(personIdent)) {
+                        database.connection.use { connection ->
+                            if (connection.getDodsdato(personIdent) == null) {
+                                connection.addPerson(
+                                    uuid = personhendelse.hendelseId,
+                                    personIdent = personIdent,
+                                    dodsdato = personhendelse.doedsfall.doedsdato,
+                                )
+                            }
+                            connection.commit()
+                        }
+                    }
+                }
+        }
+    }
+
+    suspend fun isKnownPersonIdent(personIdent: PersonIdentNumber) =
+        oppfolgingstilfelleService.getOppfolgingstilfeller(kafkaCallId(), personIdent).isNotEmpty()
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PersonhendelseService::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/personhendelse/db/PersonhendelseQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/db/PersonhendelseQueries.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.personhendelse.db
+
+import no.nav.syfo.application.database.toList
+import no.nav.syfo.database.NoElementInsertedException
+import no.nav.syfo.domain.PersonIdentNumber
+import java.sql.Connection
+import java.sql.Date
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+const val queryInsertPersonDodsdato =
+    """
+    INSERT INTO PERSON (
+        id,
+        uuid,
+        created_at,
+        personident,
+        dodsdato
+    ) values (DEFAULT, ?, ?, ?, ?)
+    RETURNING id    
+    """
+
+fun Connection.addPerson(
+    uuid: String,
+    personIdent: PersonIdentNumber,
+    dodsdato: LocalDate,
+) {
+    val idList = this.prepareStatement(queryInsertPersonDodsdato).use {
+        it.setString(1, uuid)
+        it.setObject(2, OffsetDateTime.now())
+        it.setString(3, personIdent.value)
+        it.setDate(4, Date.valueOf(dodsdato))
+        it.executeQuery().toList { getInt("id") }
+    }
+
+    if (idList.size != 1) {
+        throw NoElementInsertedException("Creating PERSON failed, no rows affected.")
+    }
+}
+
+const val queryGetPersonDodsdato =
+    """
+    SELECT DODSDATO FROM PERSON WHERE personident=?
+    """
+
+fun Connection.getDodsdato(
+    personIdent: PersonIdentNumber,
+): LocalDate? {
+    val datoList = this.prepareStatement(queryGetPersonDodsdato).use {
+        it.setString(1, personIdent.value)
+        it.executeQuery().toList { getDate("dodsdato")?.toLocalDate() }
+    }
+    return datoList.firstOrNull()
+}

--- a/src/main/kotlin/no/nav/syfo/personhendelse/db/PersonhendelseQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/db/PersonhendelseQueries.kt
@@ -7,6 +7,7 @@ import java.sql.Connection
 import java.sql.Date
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.UUID
 
 const val queryInsertPersonDodsdato =
     """
@@ -20,13 +21,13 @@ const val queryInsertPersonDodsdato =
     RETURNING id    
     """
 
-fun Connection.addPerson(
-    uuid: String,
+fun Connection.createPerson(
+    uuid: UUID,
     personIdent: PersonIdentNumber,
     dodsdato: LocalDate,
 ) {
     val idList = this.prepareStatement(queryInsertPersonDodsdato).use {
-        it.setString(1, uuid)
+        it.setString(1, uuid.toString())
         it.setObject(2, OffsetDateTime.now())
         it.setString(3, personIdent.value)
         it.setDate(4, Date.valueOf(dodsdato))

--- a/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseConsumerConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseConsumerConfig.kt
@@ -1,0 +1,28 @@
+package no.nav.syfo.personhendelse.kafka
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.syfo.application.kafka.*
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.*
+
+fun kafkaPersonhendelseConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v1"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java.canonicalName
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+
+        this[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = kafkaEnvironment.aivenSchemaRegistryUrl
+        this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
+        this[KafkaAvroDeserializerConfig.USER_INFO_CONFIG] = "${kafkaEnvironment.aivenRegistryUser}:${kafkaEnvironment.aivenRegistryPassword}"
+        this[KafkaAvroDeserializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE] = "USER_INFO"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseConsumerService.kt
@@ -1,0 +1,40 @@
+package no.nav.syfo.personhendelse.kafka
+
+import no.nav.person.pdl.leesah.Personhendelse
+import no.nav.syfo.personhendelse.PersonhendelseService
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class KafkaPersonhendelseConsumerService(
+    private val personhendelseService: PersonhendelseService,
+) {
+    val pollDurationInMillis: Long = 1000
+
+    suspend fun pollAndProcessRecords(
+        kafkaConsumer: KafkaConsumer<String, Personhendelse>,
+    ) {
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            processRecords(records)
+            kafkaConsumer.commitSync()
+        }
+    }
+
+    private suspend fun processRecords(records: ConsumerRecords<String, Personhendelse>) {
+        val (tombstoneRecords, validRecords) = records.partition { it.value() == null }
+
+        if (tombstoneRecords.isNotEmpty()) {
+            val numberOfTombstones = tombstoneRecords.size
+            log.error("Value of $numberOfTombstones ConsumerRecord are null, most probably due to a tombstone. Contact the owner of the topic if an error is suspected")
+        }
+        validRecords.forEach { record ->
+            personhendelseService.handlePersonhendelse(record.value())
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(KafkaPersonhendelseConsumerService::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseTask.kt
+++ b/src/main/kotlin/no/nav/syfo/personhendelse/kafka/KafkaPersonhendelseTask.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.personhendelse.kafka
+
+import no.nav.person.pdl.leesah.Personhendelse
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.backgroundtask.launchBackgroundTask
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.personhendelse.PersonhendelseService
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+const val PDL_LEESAH_TOPIC = "pdl.leesah-v1"
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.pdlpersonhendelse")
+
+fun launchKafkaTaskPersonhendelse(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+    database: DatabaseInterface,
+    pdlClient: PdlClient,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState,
+    ) {
+        log.info("Setting up kafka consumer for Personhendelse from PDL")
+        val oppfolgingstilfelleService = OppfolgingstilfelleService(
+            database = database,
+            pdlClient = pdlClient,
+        )
+        val personhendelseService = PersonhendelseService(
+            database = database,
+            oppfolgingstilfelleService = oppfolgingstilfelleService,
+        )
+        val kafkaPersonhendelseConsumerService = KafkaPersonhendelseConsumerService(
+            personhendelseService = personhendelseService,
+        )
+        val consumerProperties = kafkaPersonhendelseConsumerConfig(
+            kafkaEnvironment = kafkaEnvironment,
+        )
+        val kafkaConsumer = KafkaConsumer<String, Personhendelse>(consumerProperties)
+
+        kafkaConsumer.subscribe(
+            listOf(PDL_LEESAH_TOPIC)
+        )
+
+        while (applicationState.ready) {
+            kafkaPersonhendelseConsumerService.pollAndProcessRecords(
+                kafkaConsumer = kafkaConsumer,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -20,4 +20,4 @@ private val kafkaCounter = AtomicInteger(0)
 fun kafkaCallId(): String =
     "${
     LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd-MM-HHmm"))
-    }-syfosyketilfelle-kafka-${kafkaCounter.incrementAndGet()}"
+    }-isoppfolgingstilfelle-kafka-${kafkaCounter.incrementAndGet()}"

--- a/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/R__grant_to_cloudsqliamuser.sql
@@ -1,2 +1,3 @@
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM cloudsqliamuser;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudsqliamuser;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO "isyfo-analyse";

--- a/src/main/resources/db/migration/V2_3__create_table_person.sql
+++ b/src/main/resources/db/migration/V2_3__create_table_person.sql
@@ -1,0 +1,8 @@
+CREATE TABLE PERSON
+(
+    id                                  SERIAL               PRIMARY KEY,
+    uuid                                CHAR(36)             NOT NULL UNIQUE,
+    created_at                          timestamptz          NOT NULL,
+    personident                         CHAR(11)             NOT NULL UNIQUE,
+    dodsdato                            DATE
+);

--- a/src/test/kotlin/no/nav/syfo/personhendelse/KafkaPersonhendelseConsumerServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personhendelse/KafkaPersonhendelseConsumerServiceSpek.kt
@@ -5,13 +5,10 @@ import io.mockk.*
 import kotlinx.coroutines.*
 import no.nav.person.pdl.leesah.Personhendelse
 import no.nav.syfo.application.cache.RedisStore
-import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.pdl.PdlClient
-import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
 import no.nav.syfo.oppfolgingstilfelle.person.database.createOppfolgingstilfellePerson
-import no.nav.syfo.personhendelse.db.getDodsdato
 import no.nav.syfo.personhendelse.kafka.KafkaPersonhendelseConsumerService
 import no.nav.syfo.personhendelse.kafka.PDL_LEESAH_TOPIC
 import org.amshove.kluent.shouldBe
@@ -20,16 +17,14 @@ import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.common.TopicPartition
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import testhelper.ExternalMockEnvironment
-import testhelper.UserConstants
-import testhelper.dropData
+import testhelper.*
 import testhelper.generator.*
 import java.time.Duration
 import java.time.LocalDate
 
-object PersonhendelseServiceSpek : Spek({
+object KafkaPersonhendelseConsumerServiceSpek : Spek({
 
-    describe(PersonhendelseServiceSpek::class.java.simpleName) {
+    describe(KafkaPersonhendelseConsumerServiceSpek::class.java.simpleName) {
 
         with(TestApplicationEngine()) {
             start()
@@ -165,8 +160,3 @@ object PersonhendelseServiceSpek : Spek({
     }
 })
 
-fun DatabaseInterface.getDodsdato(
-    personIdent: PersonIdentNumber
-) = this.connection.use {
-    it.getDodsdato(personIdent)
-}

--- a/src/test/kotlin/no/nav/syfo/personhendelse/KafkaPersonhendelseConsumerServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personhendelse/KafkaPersonhendelseConsumerServiceSpek.kt
@@ -159,4 +159,3 @@ object KafkaPersonhendelseConsumerServiceSpek : Spek({
         }
     }
 })
-

--- a/src/test/kotlin/no/nav/syfo/personhendelse/PersonhendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personhendelse/PersonhendelseServiceSpek.kt
@@ -1,0 +1,146 @@
+package no.nav.syfo.personhendelse
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.*
+import no.nav.person.pdl.leesah.Personhendelse
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
+import no.nav.syfo.oppfolgingstilfelle.person.database.createOppfolgingstilfellePerson
+import no.nav.syfo.personhendelse.db.getDodsdato
+import no.nav.syfo.personhendelse.kafka.KafkaPersonhendelseConsumerService
+import no.nav.syfo.personhendelse.kafka.PDL_LEESAH_TOPIC
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.*
+import org.apache.kafka.common.TopicPartition
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testhelper.ExternalMockEnvironment
+import testhelper.UserConstants
+import testhelper.dropData
+import testhelper.generator.*
+import java.time.Duration
+import java.time.LocalDate
+
+object PersonhendelseServiceSpek : Spek({
+
+    describe(PersonhendelseServiceSpek::class.java.simpleName) {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+            val database = externalMockEnvironment.database
+            val mockKafkaConsumerPersonhendelse = mockk<KafkaConsumer<String, Personhendelse>>()
+
+            val pdlClient = PdlClient(
+                azureAdClient = AzureAdClient(
+                    azureEnviroment = externalMockEnvironment.environment.azure,
+                    redisStore = RedisStore(externalMockEnvironment.environment.redis),
+                ),
+                clientEnvironment = externalMockEnvironment.environment.clients.pdl,
+                redisStore = RedisStore(
+                    redisEnvironment = externalMockEnvironment.environment.redis,
+                )
+            )
+            val oppfolgingstilfelleService = OppfolgingstilfelleService(
+                database = database,
+                pdlClient = pdlClient,
+            )
+            val personhendelseService = PersonhendelseService(
+                database = database,
+                oppfolgingstilfelleService = oppfolgingstilfelleService,
+            )
+            val kafkaPersonhendelseConsumerService = KafkaPersonhendelseConsumerService(
+                personhendelseService = personhendelseService
+            )
+
+            val partition = 0
+            val personhendelseTopicPartition = TopicPartition(
+                PDL_LEESAH_TOPIC,
+                partition,
+            )
+            val personIdent = UserConstants.ARBEIDSTAKER_FNR
+            val kafkaPersonHendelse = generateKafkaPersonhendelseDTO(
+                personident = personIdent,
+            )
+            val kafkaPersonhendelseRecord = ConsumerRecord(
+                PDL_LEESAH_TOPIC,
+                partition,
+                1,
+                "key1",
+                kafkaPersonHendelse,
+            )
+
+            beforeEachTest {
+                database.dropData()
+                clearMocks(mockKafkaConsumerPersonhendelse)
+                every { mockKafkaConsumerPersonhendelse.commitSync() } returns Unit
+            }
+
+            describe("Happy path") {
+                it("Skal lagre doedsdato hvis identen er kjent") {
+
+                    val oppfolgingstilfellePerson = generateOppfolgingstilfellePerson(
+                        personIdent = personIdent,
+                    )
+
+                    database.connection.use { connection ->
+                        connection.createOppfolgingstilfellePerson(
+                            commit = true,
+                            oppfolgingstilfellePerson = oppfolgingstilfellePerson,
+                        )
+                    }
+                    every { mockKafkaConsumerPersonhendelse.poll(any<Duration>()) } returns ConsumerRecords(
+                        mapOf(
+                            personhendelseTopicPartition to listOf(
+                                kafkaPersonhendelseRecord,
+                            )
+                        )
+                    )
+                    database.getDoedsdato(personIdent) shouldBe null
+                    runBlocking {
+                        kafkaPersonhendelseConsumerService.pollAndProcessRecords(mockKafkaConsumerPersonhendelse)
+                    }
+                    verify(exactly = 1) {
+                        mockKafkaConsumerPersonhendelse.commitSync()
+                    }
+
+                    database.getDoedsdato(personIdent) shouldBeEqualTo LocalDate.now()
+                }
+            }
+
+            describe("Unhappy path") {
+                it("Skal ikke lagre dato for ukjent personident ") {
+                    every { mockKafkaConsumerPersonhendelse.poll(any<Duration>()) } returns ConsumerRecords(
+                        mapOf(
+                            personhendelseTopicPartition to listOf(
+                                kafkaPersonhendelseRecord,
+                            )
+                        )
+                    )
+                    runBlocking {
+                        kafkaPersonhendelseConsumerService.pollAndProcessRecords(mockKafkaConsumerPersonhendelse)
+                    }
+
+                    verify(exactly = 1) {
+                        mockKafkaConsumerPersonhendelse.commitSync()
+                    }
+
+                    database.getDoedsdato(personIdent) shouldBe null
+                }
+            }
+        }
+    }
+})
+
+fun DatabaseInterface.getDoedsdato(
+    personIdent: PersonIdentNumber
+) = this.connection.use {
+    it.getDodsdato(personIdent)
+}

--- a/src/test/kotlin/no/nav/syfo/personhendelse/PersonhendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personhendelse/PersonhendelseServiceSpek.kt
@@ -103,7 +103,7 @@ object PersonhendelseServiceSpek : Spek({
                             )
                         )
                     )
-                    database.getDoedsdato(personIdent) shouldBe null
+                    database.getDodsdato(personIdent) shouldBe null
                     runBlocking {
                         kafkaPersonhendelseConsumerService.pollAndProcessRecords(mockKafkaConsumerPersonhendelse)
                     }
@@ -111,7 +111,7 @@ object PersonhendelseServiceSpek : Spek({
                         mockKafkaConsumerPersonhendelse.commitSync()
                     }
 
-                    database.getDoedsdato(personIdent) shouldBeEqualTo LocalDate.now()
+                    database.getDodsdato(personIdent) shouldBeEqualTo LocalDate.now()
                 }
             }
 
@@ -132,14 +132,14 @@ object PersonhendelseServiceSpek : Spek({
                         mockKafkaConsumerPersonhendelse.commitSync()
                     }
 
-                    database.getDoedsdato(personIdent) shouldBe null
+                    database.getDodsdato(personIdent) shouldBe null
                 }
             }
         }
     }
 })
 
-fun DatabaseInterface.getDoedsdato(
+fun DatabaseInterface.getDodsdato(
     personIdent: PersonIdentNumber
 ) = this.connection.use {
     it.getDodsdato(personIdent)

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -2,6 +2,8 @@ package testhelper
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.personhendelse.db.getDodsdato
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 
@@ -57,4 +59,10 @@ fun DatabaseInterface.dropData() {
         }
         connection.commit()
     }
+}
+
+fun DatabaseInterface.getDodsdato(
+    personIdent: PersonIdentNumber
+) = this.connection.use {
+    it.getDodsdato(personIdent)
 }

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -47,6 +47,9 @@ fun DatabaseInterface.dropData() {
         """
         DELETE FROM OPPFOLGINGSTILFELLE_PERSON
         """.trimIndent(),
+        """
+        DELETE FROM PERSON
+        """.trimIndent(),
     )
     this.connection.use { connection ->
         queryList.forEach { query ->

--- a/src/test/kotlin/testhelper/generator/GenerateOppfolgingstilfellePerson.kt
+++ b/src/test/kotlin/testhelper/generator/GenerateOppfolgingstilfellePerson.kt
@@ -1,15 +1,18 @@
 package testhelper.generator
 
+import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.person.domain.*
 import no.nav.syfo.util.nowUTC
 import testhelper.UserConstants
 import java.time.LocalDate
 import java.util.*
 
-fun generateOppfolgingstilfellePerson() = OppfolgingstilfellePerson(
+fun generateOppfolgingstilfellePerson(
+    personIdent: PersonIdentNumber = UserConstants.PERSONIDENTNUMBER_DEFAULT,
+) = OppfolgingstilfellePerson(
     uuid = UUID.randomUUID(),
     createdAt = nowUTC(),
-    personIdentNumber = UserConstants.PERSONIDENTNUMBER_DEFAULT,
+    personIdentNumber = personIdent,
     oppfolgingstilfelleList = listOf(
         Oppfolgingstilfelle(
             arbeidstakerAtTilfelleEnd = false,

--- a/src/test/kotlin/testhelper/generator/KafkaPersonhendelseDTOGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/KafkaPersonhendelseDTOGenerator.kt
@@ -1,0 +1,22 @@
+package testhelper.generator
+
+import no.nav.person.pdl.leesah.Endringstype
+import no.nav.person.pdl.leesah.Personhendelse
+import no.nav.person.pdl.leesah.doedsfall.Doedsfall
+import no.nav.syfo.domain.PersonIdentNumber
+import testhelper.UserConstants
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+fun generateKafkaPersonhendelseDTO(
+    personident: PersonIdentNumber = UserConstants.ARBEIDSTAKER_FNR,
+) = Personhendelse().apply {
+    hendelseId = UUID.randomUUID().toString()
+    personidenter = listOf(personident.value)
+    opprettet = Instant.now()
+    doedsfall = Doedsfall().apply {
+        doedsdato = LocalDate.now()
+    }
+    endringstype = Endringstype.OPPRETTET
+}


### PR DESCRIPTION
I første omgang lagrer dette relevante dødsfall, dvs for personident'er der vi har oppfølgingstilfeller i databasen. I neste PR tenkte jeg å legge til dodsdato som et felt i oppfølgingstilfelle-dto'ene som brukes på Kafka-topic og som returneres i rest-api.