### PR TITLE
Tilpasset gradertAtTilfelleEnd til å sjekke om gradert i alle arbeidsforhold på slutten av oppfølgingstilfellet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -87,16 +87,20 @@ data class OppfolgingstilfelleBit(
 }
 
 fun List<OppfolgingstilfelleBit>.generateOppfolgingstilfelleList(): List<Oppfolgingstilfelle> {
-    val filtrertOppfolgingstilfelleList = this.filtrerOppfolgingstilfelleList()
-    return if (filtrertOppfolgingstilfelleList.isEmpty()) {
+    val filtrertOppfolgingstilfelleBitList = this.filtrerOppfolgingstilfelleBitList()
+    return if (filtrertOppfolgingstilfelleBitList.isEmpty()) {
         emptyList()
     } else {
-        filtrertOppfolgingstilfelleList.toOppfolgingstilfelleDagList()
-            .groupOppfolgingstilfelleList()
+        val oppfolgingstilfelleBiterPerVirksomhet = filtrertOppfolgingstilfelleBitList.groupBy { it.virksomhetsnummer }
+        val oppfolgingstilfelleDagerPerVirksomhet =
+            oppfolgingstilfelleBiterPerVirksomhet.mapValues { it.value.toOppfolgingstilfelleDagList() }
+
+        filtrertOppfolgingstilfelleBitList.toOppfolgingstilfelleDagList()
+            .groupOppfolgingstilfelleList(oppfolgingstilfelleDagerPerVirksomhet)
     }
 }
 
-private fun List<OppfolgingstilfelleBit>.filtrerOppfolgingstilfelleList(): List<OppfolgingstilfelleBit> {
+private fun List<OppfolgingstilfelleBit>.filtrerOppfolgingstilfelleBitList(): List<OppfolgingstilfelleBit> {
     val korrigerte = this.mapNotNull { bit -> bit.korrigerer?.toString() }
     return this.filter { bit -> !korrigerte.contains(bit.ressursId) }
 }


### PR DESCRIPTION
Tanken er at isaktivitetskrav skal kunne bruke dette til å beregne om det skal genereres aktivitetskrav (dersom gradert i alle -> automatisk oppfylt, hvis ikke -> nytt aktivitetskrav) (Eller trenger vi nytt felt som inneholder gradering per arbeidsforhold?)
Kan utvide med noen tester senere hvis vi tenker at dette er OK.