### PR TITLE
Resize prod-db (more ram)

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -43,7 +43,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
-        tier: db-custom-1-768
+        tier: db-custom-1-1024
         databases:
           - name: isoppfolgingstilfelle-db
         diskAutoresize: true

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -43,7 +43,6 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
-        tier: db-custom-1-3840
         databases:
           - name: isoppfolgingstilfelle-db
         diskAutoresize: true

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -43,7 +43,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
-        tier: db-custom-1-1024
+        tier: db-custom-1-3840
         databases:
           - name: isoppfolgingstilfelle-db
         diskAutoresize: true

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -43,6 +43,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-768
         databases:
           - name: isoppfolgingstilfelle-db
         diskAutoresize: true

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -43,6 +43,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-3840
         databases:
           - name: isoppfolgingstilfelle-db
         diskAutoresize: true


### PR DESCRIPTION
GCP advarer om at ram-bruken er høy, så vi bør allokere mer. Verdien man setter på være en multippel av 256.