### PR TITLE
Skip processing of non-updated identer and enable identhendelser in prod

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -98,5 +98,3 @@ spec:
       value: "https://aareg-services-q1.dev-fss-pub.nais.io"
     - name: ARBEIDSFORHOLD_CLIENT_ID
       value: "dev-fss.arbeidsforhold.aareg-services-nais-q1"
-    - name: TOGGLE_KAFKA_IDENTHENDELSE_ENABLED
-      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -99,5 +99,3 @@ spec:
       value: "https://aareg-services.prod-fss-pub.nais.io"
     - name: ARBEIDSFORHOLD_CLIENT_ID
       value: "prod-fss.arbeidsforhold.aareg-services-nais"
-    - name: TOGGLE_KAFKA_IDENTHENDELSE_ENABLED
-      value: "false"

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -107,21 +107,20 @@ fun main() {
             kafkaEnvironment = environment.kafka,
             kafkaSyketilfellebitService = kafkaSyketilfellebitService,
         )
-        if (environment.kafkaIdenthendelseUpdatesEnabled) {
-            val identhendelseService = IdenthendelseService(
-                database = applicationDatabase,
-                pdlClient = pdlClient,
-            )
 
-            val kafkaIdenthendelseConsumerService = IdenthendelseConsumerService(
-                identhendelseService = identhendelseService,
-            )
-            launchKafkaTaskIdenthendelse(
-                applicationState = applicationState,
-                kafkaEnvironment = environment.kafka,
-                kafkaIdenthendelseConsumerService = kafkaIdenthendelseConsumerService,
-            )
-        }
+        val identhendelseService = IdenthendelseService(
+            database = applicationDatabase,
+            pdlClient = pdlClient,
+        )
+        val kafkaIdenthendelseConsumerService = IdenthendelseConsumerService(
+            identhendelseService = identhendelseService,
+        )
+        launchKafkaTaskIdenthendelse(
+            applicationState = applicationState,
+            kafkaEnvironment = environment.kafka,
+            kafkaIdenthendelseConsumerService = kafkaIdenthendelseConsumerService,
+        )
+
         launchKafkaTaskPersonhendelse(
             applicationState = applicationState,
             kafkaEnvironment = environment.kafka,

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -71,8 +71,6 @@ data class Environment(
         ),
     ),
 
-    val kafkaIdenthendelseUpdatesEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_IDENTHENDELSE_ENABLED").toBoolean(),
-
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
     private val isdialogmoteApplicationName: String = "isdialogmote",
     private val isdialogmotekandidatApplicationName: String = "isdialogmotekandidat",

--- a/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/identhendelse/IdenthendelseService.kt
@@ -7,8 +7,11 @@ import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.identhendelse.database.*
 import no.nav.syfo.identhendelse.kafka.COUNT_KAFKA_CONSUMER_PDL_AKTOR_UPDATES
 import no.nav.syfo.identhendelse.kafka.KafkaIdenthendelseDTO
+import no.nav.syfo.oppfolgingstilfelle.bit.database.getOppfolgingstilfelleBitForIdent
+import no.nav.syfo.oppfolgingstilfelle.person.database.getOppfolgingstilfellePerson
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class IdenthendelseService(
     private val database: DatabaseInterface,
@@ -38,11 +41,15 @@ class IdenthendelseService(
         val inactiveIdenterCount = database.getIdentCount(inactiveIdenter)
 
         if (inactiveIdenterCount > 0) {
-            checkThatPdlIsUpdated(activeIdent)
-            database.connection.use { connection ->
-                numberOfUpdatedIdenter += connection.updateTilfelleBit(activeIdent, inactiveIdenter)
-                numberOfUpdatedIdenter += connection.updateOppfolgingstilfellePerson(activeIdent, inactiveIdenter)
-                connection.commit()
+            val bitUuid = database.getOppfolgingstilfelleBitForIdent(inactiveIdenter.first()).firstOrNull()?.uuid
+            val tilfelleUuid = database.getOppfolgingstilfellePerson(inactiveIdenter.first())?.uuid
+            val isUpdatedInPdl = checkThatPdlIsUpdated(activeIdent, bitUuid, tilfelleUuid)
+            if (isUpdatedInPdl) {
+                database.connection.use { connection ->
+                    numberOfUpdatedIdenter += connection.updateTilfelleBit(activeIdent, inactiveIdenter)
+                    numberOfUpdatedIdenter += connection.updateOppfolgingstilfellePerson(activeIdent, inactiveIdenter)
+                    connection.commit()
+                }
             }
         }
 
@@ -50,12 +57,16 @@ class IdenthendelseService(
     }
 
     // Erfaringer fra andre team tilsier at vi burde dobbeltsjekke at ting har blitt oppdatert i PDL før vi gjør endringer
-    private fun checkThatPdlIsUpdated(nyIdent: PersonIdentNumber) {
+    private fun checkThatPdlIsUpdated(nyIdent: PersonIdentNumber, bitUuid: UUID?, tilfelleUuid: UUID?): Boolean {
+        var isUpdated = true
         runBlocking {
             val pdlIdenter = pdlClient.pdlIdenter(nyIdent)?.hentIdenter ?: throw RuntimeException("Fant ingen identer fra PDL")
             if (nyIdent.value != pdlIdenter.aktivIdent && pdlIdenter.identhendelseIsNotHistorisk(nyIdent.value)) {
-                throw IllegalStateException("Ny ident er ikke aktiv ident i PDL")
+                log.warn("Identhendelse: Could not update ident with bitUuid $bitUuid or tilfelleUuid $tilfelleUuid, skipping identhendelse")
+                isUpdated = false
+//                throw IllegalStateException("Ny ident er ikke aktiv ident i PDL")
             }
         }
+        return isUpdated
     }
 }

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -76,7 +76,6 @@ fun testEnvironment(
         port = 6379,
         secret = "password",
     ),
-    kafkaIdenthendelseUpdatesEnabled = true,
 )
 
 fun testAppState() = ApplicationState(


### PR DESCRIPTION
Dette blir samme case som i `syfooversiktsrv` (ettersom at tilfellene der har kommet herfra). Der var det 11 (av 10 millioner) man måtte manuelt skippe, så vi får se hvordan det går denne gangen 😬 