### PR TITLE
Throw error when ny ident not updated in pdl-api

### DIFF
--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.identhendelse.database.getIdentCount
 import no.nav.syfo.oppfolgingstilfelle.bit.database.createOppfolgingstilfelleBit
 import no.nav.syfo.oppfolgingstilfelle.bit.domain.toOppfolgingstilfelleBit
 import no.nav.syfo.oppfolgingstilfelle.person.database.createOppfolgingstilfellePerson
+import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -71,22 +72,7 @@ object IdenthendelseServiceSpek : Spek({
             }
 
             describe("Unhappy path") {
-//                it("Skal kaste feil hvis PDL ikke har oppdatert identen") {
-//                    val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(
-//                        personident = UserConstants.ARBEIDSTAKER_3_FNR,
-//                        hasOldPersonident = true,
-//                    )
-//                    val oldIdent = kafkaIdenthendelseDTO.getInactivePersonidenter().first()
-//
-//                    populateDatabase(oldIdent, database)
-//
-//                    runBlocking {
-//                        assertFailsWith(IllegalStateException::class) {
-//                            identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
-//                        }
-//                    }
-//                }
-                it("Skal hoppe over record hvis PDL ikke har oppdatert identen") {
+                it("Skal kaste feil hvis PDL ikke har oppdatert identen") {
                     val kafkaIdenthendelseDTO = generateKafkaIdenthendelseDTO(
                         personident = UserConstants.ARBEIDSTAKER_3_FNR,
                         hasOldPersonident = true,
@@ -95,17 +81,11 @@ object IdenthendelseServiceSpek : Spek({
 
                     populateDatabase(oldIdent, database)
 
-                    val oldIdentOccurrences = database.getIdentCount(listOf(oldIdent)) + database.getIdentCount(listOf(UserConstants.ARBEIDSTAKER_4_FNR))
-                    oldIdentOccurrences shouldBeEqualTo 2
-
                     runBlocking {
-                        identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+                        assertFailsWith(IllegalStateException::class) {
+                            identhendelseService.handleIdenthendelse(kafkaIdenthendelseDTO)
+                        }
                     }
-
-                    val oldIdentOccurrencesNotUpdated = database.getIdentCount(listOf(oldIdent)) + database.getIdentCount(listOf(UserConstants.ARBEIDSTAKER_4_FNR))
-                    oldIdentOccurrencesNotUpdated shouldBeEqualTo 2
-                    val newIdentOccurrences = database.getIdentCount(listOf(kafkaIdenthendelseDTO.getActivePersonident()!!))
-                    newIdentOccurrences shouldBeEqualTo 0
                 }
             }
         }


### PR DESCRIPTION
Venter på at den skal kjøre gjennom de historiske identhendelsene før denne kan "endre tilbake" igjen.