### PR TITLE
Remove incorrect soknad bit

### DIFF
--- a/src/main/resources/db/migration/V2_6__remove_incorrect_soknad.sql
+++ b/src/main/resources/db/migration/V2_6__remove_incorrect_soknad.sql
@@ -1,0 +1,2 @@
+DELETE FROM TILFELLE_BIT where uuid='bf49d630-e445-47b0-9086-443ab961e055';
+UPDATE TILFELLE_BIT SET processed=false where uuid='ecc6f711-f2a4-484a-b4cc-2aeddbf5dbbb';


### PR DESCRIPTION
Delete entire bit because the correct part of the soknad, with expected fom/tom, is a seperate bit. Reprocess newest bit to regenerate tilfelle.
https://jira.adeo.no/browse/FAGSYSTEM-270352