### PR TITLE
Consumer for sykmelding-statusendring

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -82,6 +82,8 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
+    - name: TOOGLE_SYKMELDING_STATUS_CONSUMER_ENABLED
+      value: "true"
     - name: PDL_CLIENT_ID
       value: "dev-fss.pdl.pdl-api"
     - name: PDL_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -83,6 +83,8 @@ spec:
   env:
     - name: KTOR_ENV
       value: "production"
+    - name: TOOGLE_SYKMELDING_STATUS_CONSUMER_ENABLED
+      value: "false"
     - name: PDL_CLIENT_ID
       value: "prod-fss.pdl.pdl-api"
     - name: PDL_URL

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -13,8 +13,8 @@ import no.nav.syfo.application.database.applicationDatabase
 import no.nav.syfo.application.database.databaseModule
 import no.nav.syfo.client.wellknown.getWellKnown
 import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.KafkaSyketilfellebitService
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.launchKafkaTaskSyketilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.KafkaSyketilfellebitService
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.launchKafkaTaskSyketilfelleBit
 import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
 import no.nav.syfo.application.cronjob.launchCronjobModule
 import no.nav.syfo.client.azuread.AzureAdClient
@@ -22,6 +22,8 @@ import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.identhendelse.IdenthendelseService
 import no.nav.syfo.identhendelse.kafka.IdenthendelseConsumerService
 import no.nav.syfo.identhendelse.kafka.launchKafkaTaskIdenthendelse
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring.KafkaStatusendringService
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring.launchKafkaTaskStatusendring
 import no.nav.syfo.oppfolgingstilfelle.person.kafka.OppfolgingstilfellePersonProducer
 import no.nav.syfo.oppfolgingstilfelle.person.kafka.kafkaOppfolgingstilfelleProducerConfig
 import no.nav.syfo.personhendelse.kafka.launchKafkaTaskPersonhendelse
@@ -107,6 +109,19 @@ fun main() {
             kafkaEnvironment = environment.kafka,
             kafkaSyketilfellebitService = kafkaSyketilfellebitService,
         )
+
+        if (environment.sykmeldingStatusConsumerEnabled) {
+            val kafkaStatusendringService = KafkaStatusendringService(
+                database = applicationDatabase,
+                oppfolgingstilfelleBitService = OppfolgingstilfelleBitService(),
+            )
+
+            launchKafkaTaskStatusendring(
+                applicationState = applicationState,
+                kafkaEnvironment = environment.kafka,
+                kafkaStatusendringService = kafkaStatusendringService,
+            )
+        }
 
         val identhendelseService = IdenthendelseService(
             database = applicationDatabase,

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -72,6 +72,7 @@ data class Environment(
     ),
 
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
+    val sykmeldingStatusConsumerEnabled: Boolean = getEnvVar("TOOGLE_SYKMELDING_STATUS_CONSUMER_ENABLED").toBoolean(),
     private val isdialogmoteApplicationName: String = "isdialogmote",
     private val isdialogmotekandidatApplicationName: String = "isdialogmotekandidat",
     val systemAPIAuthorizedConsumerApplicationNames: List<String> = listOf(

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitService.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.oppfolgingstilfelle.bit.database.*
 import no.nav.syfo.oppfolgingstilfelle.bit.database.domain.toOppfolgingstilfelleBit
 import no.nav.syfo.oppfolgingstilfelle.bit.database.domain.toOppfolgingstilfelleBitList
 import no.nav.syfo.oppfolgingstilfelle.bit.domain.*
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.*
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.*
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/domain/Oppfolgingstilfellebit.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.oppfolgingstilfelle.bit.domain
 
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.bit.domain.OppfolgingstilfelleBit.Companion.TAG_PRIORITY
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.KafkaSyketilfellebit
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.KafkaSyketilfellebit
 import no.nav.syfo.oppfolgingstilfelle.person.domain.*
 import no.nav.syfo.util.*
 import java.time.*

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendring.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendring.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import java.time.OffsetDateTime
+
+const val STATUS_APEN = "APEN"
+const val STATUS_AVBRUTT = "AVBRUTT"
+const val STATUS_UTGATT = "UTGATT"
+const val STATUS_SENDT = "SENDT"
+const val STATUS_BEKREFTET = "BEKREFTET"
+const val STATUS_SLETTET = "SLETTET"
+
+data class SykmeldingStatusKafkaMessageDTO(
+    val kafkaMetadata: KafkaMetadataDTO,
+    val event: SykmeldingStatusKafkaEventDTO
+)
+
+data class KafkaMetadataDTO(
+    val sykmeldingId: String,
+    val timestamp: OffsetDateTime,
+    val fnr: String,
+    val source: String
+)
+
+data class SykmeldingStatusKafkaEventDTO(
+    val sykmeldingId: String,
+    val timestamp: OffsetDateTime,
+    val statusEvent: String,
+    val arbeidsgiver: ArbeidsgiverStatusDTO? = null,
+    val erSvarOppdatering: Boolean? = null,
+)
+
+data class ArbeidsgiverStatusDTO(
+    val orgnummer: String,
+    val juridiskOrgnummer: String? = null,
+    val orgNavn: String
+)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringConfig.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
 
 import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.application.kafka.commonKafkaAivenConfig
@@ -6,16 +6,16 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 import java.util.*
 
-fun kafkaSyketilfelleBitConsumerConfig(
+fun kafkaStatusendringConsumerConfig(
     kafkaEnvironment: KafkaEnvironment,
 ): Properties {
     return Properties().apply {
         putAll(commonKafkaAivenConfig(kafkaEnvironment))
 
-        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v4"
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v1"
         this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
         this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
-            KafkaSyketilfellebitDeserializer::class.java.canonicalName
+            KafkaStatusendringDeserializer::class.java.canonicalName
         this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
         this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
         this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringDeserializer.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringDeserializer.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Deserializer
+
+class KafkaStatusendringDeserializer : Deserializer<SykmeldingStatusKafkaMessageDTO?> {
+    private val mapper = configuredJacksonMapper()
+
+    override fun deserialize(topic: String, data: ByteArray): SykmeldingStatusKafkaMessageDTO? =
+        mapper.readValue(data, SykmeldingStatusKafkaMessageDTO::class.java)
+
+    override fun close() {}
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringMetric.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.application.metric.METRICS_NS
+import no.nav.syfo.application.metric.METRICS_REGISTRY
+
+const val KAFKA_CONSUMER_STATUSENDRING_BASE = "${METRICS_NS}_kafka_consumer_statusendring"
+const val KAFKA_CONSUMER_STATUSENDRING_READ = "${KAFKA_CONSUMER_STATUSENDRING_BASE}_read"
+const val KAFKA_CONSUMER_STATUSENDRING_TOMBSTONE = "${KAFKA_CONSUMER_STATUSENDRING_BASE}_tombstone"
+
+val COUNT_KAFKA_CONSUMER_STATUSENDRING_READ: Counter = Counter.builder(KAFKA_CONSUMER_STATUSENDRING_READ)
+    .description("Counts the number of reads from topic - sykmeldingstatus-leesah")
+    .register(METRICS_REGISTRY)
+val COUNT_KAFKA_CONSUMER_STATUSENDRING_TOMBSTONE: Counter = Counter.builder(KAFKA_CONSUMER_STATUSENDRING_TOMBSTONE)
+    .description("Counts the number of tombstones received from topic - sykmeldingstatus-leesah")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringService.kt
@@ -1,0 +1,85 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
+import no.nav.syfo.oppfolgingstilfelle.bit.database.*
+import org.apache.kafka.clients.consumer.*
+import org.slf4j.LoggerFactory
+import java.sql.Connection
+import java.time.*
+
+val STATUS_ENDRING_CUTOFF = OffsetDateTime.of(
+    LocalDate.of(2023, 1, 1),
+    LocalTime.MIN,
+    ZoneOffset.UTC,
+)
+
+class KafkaStatusendringService(
+    val database: DatabaseInterface,
+    val oppfolgingstilfelleBitService: OppfolgingstilfelleBitService,
+) {
+    fun pollAndProcessRecords(
+        kafkaConsumerStatusendring: KafkaConsumer<String, SykmeldingStatusKafkaMessageDTO>,
+    ) {
+        val records = kafkaConsumerStatusendring.poll(Duration.ofMillis(1000))
+        if (records.count() > 0) {
+            processRecords(
+                consumerRecords = records,
+            )
+            kafkaConsumerStatusendring.commitSync()
+        }
+    }
+
+    private fun processRecords(
+        consumerRecords: ConsumerRecords<String, SykmeldingStatusKafkaMessageDTO>,
+    ) {
+        database.connection.use { connection ->
+            COUNT_KAFKA_CONSUMER_STATUSENDRING_READ.increment(consumerRecords.count().toDouble())
+
+            val (tombstoneRecordList, relevantRecordList) = consumerRecords.partition {
+                it.value() == null
+            }
+            processTombstoneRecordList(
+                tombstoneRecordList = tombstoneRecordList,
+            )
+
+            processRelevantRecordList(
+                connection = connection,
+                relevantRecordList = relevantRecordList
+            )
+            connection.commit()
+        }
+    }
+
+    private fun processTombstoneRecordList(
+        tombstoneRecordList: List<ConsumerRecord<String, SykmeldingStatusKafkaMessageDTO>>,
+    ) {
+        COUNT_KAFKA_CONSUMER_STATUSENDRING_TOMBSTONE.increment(tombstoneRecordList.size.toDouble())
+    }
+
+    private fun processRelevantRecordList(
+        connection: Connection,
+        relevantRecordList: List<ConsumerRecord<String, SykmeldingStatusKafkaMessageDTO>>,
+    ) {
+        relevantRecordList.forEach { consumerRecord ->
+            val kafkaSykmeldingStatus = consumerRecord.value()
+            val inntruffet = kafkaSykmeldingStatus.event.timestamp
+            if (inntruffet.isAfter(STATUS_ENDRING_CUTOFF) && kafkaSykmeldingStatus.event.statusEvent == STATUS_AVBRUTT) {
+                val oppfolgingstilfelleBitList = connection.getOppfolgingstilfelleBitForRessursId(
+                    ressursId = kafkaSykmeldingStatus.event.sykmeldingId,
+                )
+                oppfolgingstilfelleBitList.forEach { pOppfolgingstilfelleBit ->
+                    connection.createOppfolgingstilfelleBitAvbrutt(
+                        pOppfolgingstilfelleBit = pOppfolgingstilfelleBit,
+                        inntruffet = inntruffet,
+                        avbrutt = true,
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(KafkaStatusendringService::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringTask.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.application.ApplicationState
+import no.nav.syfo.application.backgroundtask.launchBackgroundTask
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+const val STATUSENDRING_TOPIC = "teamsykmelding.sykmeldingstatus-leesah"
+
+fun launchKafkaTaskStatusendring(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+    kafkaStatusendringService: KafkaStatusendringService,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState,
+    ) {
+        blockingApplicationLogicStatusendring(
+            applicationState = applicationState,
+            kafkaEnvironment = kafkaEnvironment,
+            kafkaStatusendringService = kafkaStatusendringService,
+        )
+    }
+}
+
+fun blockingApplicationLogicStatusendring(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+    kafkaStatusendringService: KafkaStatusendringService,
+) {
+    log.info("Setting up kafka consumer for KafkaStatusendring")
+
+    val consumerProperties = kafkaStatusendringConsumerConfig(kafkaEnvironment)
+    val kafkaConsumerStatusendring = KafkaConsumer<String, SykmeldingStatusKafkaMessageDTO>(consumerProperties)
+
+    kafkaConsumerStatusendring.subscribe(
+        listOf(STATUSENDRING_TOPIC)
+    )
+    while (applicationState.ready) {
+        kafkaStatusendringService.pollAndProcessRecords(
+            kafkaConsumerStatusendring = kafkaConsumerStatusendring,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitMetric.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import io.micrometer.core.instrument.Counter
 import no.nav.syfo.application.metric.METRICS_NS
@@ -18,13 +18,17 @@ val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_READ: Counter = Counter.builder(KAFKA_C
 val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_CREATED: Counter = Counter.builder(KAFKA_CONSUMER_SYKETILFELLEBIT_CREATED)
     .description("Counts the number of created from topic - syketilfellebit")
     .register(METRICS_REGISTRY)
-val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_SKIPPED_CREATE: Counter = Counter.builder(KAFKA_CONSUMER_SYKETILFELLEBIT_SKIPPED_CREATE)
+val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_SKIPPED_CREATE: Counter = Counter.builder(
+    KAFKA_CONSUMER_SYKETILFELLEBIT_SKIPPED_CREATE
+)
     .description("Counts the number of skipped from topic - syketilfellebit")
     .register(METRICS_REGISTRY)
 val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_DUPLICATE: Counter = Counter.builder(KAFKA_CONSUMER_SYKETILFELLEBIT_DUPLICATE)
     .description("Counts the number of duplicates received from topic - syketilfellebit")
     .register(METRICS_REGISTRY)
-val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_NOT_RELEVANT: Counter = Counter.builder(KAFKA_CONSUMER_SYKETILFELLEBIT_NOT_RELEVANT)
+val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_NOT_RELEVANT: Counter = Counter.builder(
+    KAFKA_CONSUMER_SYKETILFELLEBIT_NOT_RELEVANT
+)
     .description("Counts the number of not relevant and skipped records from topic - syketilfellebit")
     .register(METRICS_REGISTRY)
 val COUNT_KAFKA_CONSUMER_SYKETILFELLEBIT_TOMBSTONE: Counter = Counter.builder(KAFKA_CONSUMER_SYKETILFELLEBIT_TOMBSTONE)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitTask.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitTask.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.application.ApplicationState

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleConfig.kt
@@ -1,0 +1,24 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
+
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.application.kafka.commonKafkaAivenConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.*
+
+fun kafkaSyketilfelleBitConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
+
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isoppfolgingstilfelle-v4"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] =
+            KafkaSyketilfellebitDeserializer::class.java.canonicalName
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebit.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import no.nav.syfo.oppfolgingstilfelle.bit.domain.Tag
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebitDeserializer.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebitDeserializer.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import no.nav.syfo.util.configuredJacksonMapper
 import org.apache.kafka.common.serialization.Deserializer

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebitService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfellebitService.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.bit.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService

--- a/src/main/resources/db/migration/V2_9__create_table_oppfolgingstilfelle_bit_avbrutt.sql
+++ b/src/main/resources/db/migration/V2_9__create_table_oppfolgingstilfelle_bit_avbrutt.sql
@@ -1,0 +1,14 @@
+CREATE TABLE TILFELLE_BIT_AVBRUTT
+(
+    id                           SERIAL               PRIMARY KEY,
+    uuid                         CHAR(36)             NOT NULL UNIQUE,
+    created_at                   timestamptz          NOT NULL,
+    updated_at                   timestamptz          NOT NULL,
+    tilfelle_bit_id              INTEGER REFERENCES TILFELLE_BIT (id) ON DELETE CASCADE,
+    inntruffet                   timestamptz          NOT NULL,
+    avbrutt                      BOOLEAN              NOT NULL
+);
+
+CREATE INDEX IX_TILFELLE_BIT_AVBRUTT_TILFELLE_BIT on TILFELLE_BIT_AVBRUTT (tilfelle_bit_id);
+
+CREATE INDEX IX_TILFELLE_BIT_RESSURS_ID on TILFELLE_BIT (ressurs_id);

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiSpek.kt
@@ -8,7 +8,7 @@ import io.mockk.*
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
 import no.nav.syfo.oppfolgingstilfelle.bit.cronjob.OppfolgingstilfelleCronjob
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.*
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.*
 import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
 import no.nav.syfo.oppfolgingstilfelle.person.api.domain.OppfolgingstilfellePersonDTO
 import no.nav.syfo.oppfolgingstilfelle.person.api.oppfolgingstilfelleApiPersonIdentPath

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiSpek.kt
@@ -7,7 +7,7 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
 import no.nav.syfo.oppfolgingstilfelle.bit.cronjob.OppfolgingstilfelleCronjob
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.*
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.*
 import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
 import no.nav.syfo.oppfolgingstilfelle.person.api.domain.OppfolgingstilfellePersonDTO
 import no.nav.syfo.oppfolgingstilfelle.person.api.oppfolgingstilfelleSystemApiPersonIdentPath

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/statusendring/KafkaStatusendringConsumerSpek.kt
@@ -1,0 +1,151 @@
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
+import no.nav.syfo.oppfolgingstilfelle.bit.database.createOppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.domain.OppfolgingstilfelleBit
+import no.nav.syfo.oppfolgingstilfelle.bit.domain.Tag
+import no.nav.syfo.util.*
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.consumer.*
+import org.apache.kafka.common.TopicPartition
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import testhelper.*
+import testhelper.UserConstants.PERSONIDENTNUMBER_DEFAULT
+import testhelper.generator.*
+import testhelper.mock.toHistoricalPersonIdentNumber
+import java.time.Duration
+import java.time.LocalDate
+import java.util.*
+
+class KafkaStatusendringConsumerSpek : Spek({
+
+    with(TestApplicationEngine()) {
+        start()
+
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val oppfolgingstilfelleBitService = OppfolgingstilfelleBitService()
+
+        application.testApiModule(
+            externalMockEnvironment = externalMockEnvironment,
+        )
+
+        val kafkaStatusendringService = KafkaStatusendringService(
+            database = database,
+            oppfolgingstilfelleBitService = oppfolgingstilfelleBitService,
+        )
+        val personIdentDefault = PERSONIDENTNUMBER_DEFAULT.toHistoricalPersonIdentNumber()
+        val sykmeldingId = UUID.randomUUID()
+        val tilfelleBitUuid = UUID.randomUUID()
+
+        val oppfolgingstilfelleBit = OppfolgingstilfelleBit(
+            uuid = tilfelleBitUuid,
+            personIdentNumber = personIdentDefault,
+            virksomhetsnummer = null,
+            createdAt = nowUTC(),
+            inntruffet = nowUTC().minusDays(1),
+            fom = LocalDate.now().minusDays(1),
+            tom = LocalDate.now().plusDays(1),
+            tagList = listOf(
+                Tag.SYKMELDING,
+                Tag.NY,
+            ),
+            ressursId = sykmeldingId.toString(),
+            korrigerer = null,
+        )
+
+        val statusendringTopicPartition = TopicPartition(
+            STATUSENDRING_TOPIC,
+            0,
+        )
+
+        val statusendring = generateKafkaStatusendring(
+            sykmeldingId = sykmeldingId,
+            personIdentNumber = personIdentDefault,
+        )
+        val kafkaStatusendring = ConsumerRecord(
+            STATUSENDRING_TOPIC,
+            0,
+            1,
+            sykmeldingId.toString(),
+            statusendring,
+        )
+        val unknownSykmeldingId = UUID.randomUUID()
+        val statusendringUnknownSykmelding = generateKafkaStatusendring(
+            sykmeldingId = unknownSykmeldingId,
+            personIdentNumber = personIdentDefault,
+        )
+        val kafkaStatusendringUnknownSykmelding = ConsumerRecord(
+            STATUSENDRING_TOPIC,
+            0,
+            1,
+            unknownSykmeldingId.toString(),
+            statusendringUnknownSykmelding,
+        )
+        val mockKafkaConsumerStatusendring = mockk<KafkaConsumer<String, SykmeldingStatusKafkaMessageDTO>>()
+
+        beforeEachTest {
+            database.dropData()
+            database.connection.use {
+                it.createOppfolgingstilfelleBit(
+                    commit = true,
+                    oppfolgingstilfelleBit = oppfolgingstilfelleBit,
+                )
+            }
+
+            clearMocks(mockKafkaConsumerStatusendring)
+            every { mockKafkaConsumerStatusendring.commitSync() } returns Unit
+        }
+
+        describe(KafkaStatusendringConsumerSpek::class.java.simpleName) {
+            describe("Consume statusendring from Kafka topic") {
+                describe("Happy path") {
+                    it("should store statusendring when known sykmeldingId") {
+                        database.isTilfelleBitAvbrutt(tilfelleBitUuid) shouldBeEqualTo false
+                        every { mockKafkaConsumerStatusendring.poll(any<Duration>()) } returns ConsumerRecords(
+                            mapOf(
+                                statusendringTopicPartition to listOf(
+                                    kafkaStatusendring
+                                )
+                            )
+                        )
+
+                        kafkaStatusendringService.pollAndProcessRecords(
+                            kafkaConsumerStatusendring = mockKafkaConsumerStatusendring,
+                        )
+
+                        verify(exactly = 1) {
+                            mockKafkaConsumerStatusendring.commitSync()
+                        }
+
+                        database.isTilfelleBitAvbrutt(tilfelleBitUuid) shouldBeEqualTo true
+                    }
+                    it("should consume statusendring with unknown sykmeldingId") {
+                        database.isTilfelleBitAvbrutt(tilfelleBitUuid) shouldBeEqualTo false
+                        every { mockKafkaConsumerStatusendring.poll(any<Duration>()) } returns ConsumerRecords(
+                            mapOf(
+                                statusendringTopicPartition to listOf(
+                                    kafkaStatusendringUnknownSykmelding
+                                )
+                            )
+                        )
+
+                        kafkaStatusendringService.pollAndProcessRecords(
+                            kafkaConsumerStatusendring = mockKafkaConsumerStatusendring,
+                        )
+
+                        verify(exactly = 1) {
+                            mockKafkaConsumerStatusendring.commitSync()
+                        }
+
+                        database.isTilfelleBitAvbrutt(tilfelleBitUuid) shouldBeEqualTo false
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitConsumerSpek.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.oppfolgingstilfelle.kafka
+package no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -12,9 +12,6 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.oppfolgingstilfelle.bit.OppfolgingstilfelleBitService
 import no.nav.syfo.oppfolgingstilfelle.bit.cronjob.OppfolgingstilfelleCronjob
 import no.nav.syfo.oppfolgingstilfelle.bit.cronjob.SykmeldingNyCronjob
-import no.nav.syfo.oppfolgingstilfelle.bit.domain.OppfolgingstilfelleBit
-import no.nav.syfo.oppfolgingstilfelle.bit.domain.Tag
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.*
 import no.nav.syfo.oppfolgingstilfelle.person.OppfolgingstilfellePersonService
 import no.nav.syfo.oppfolgingstilfelle.person.api.domain.OppfolgingstilfellePersonDTO
 import no.nav.syfo.oppfolgingstilfelle.person.api.oppfolgingstilfelleApiPersonIdentPath
@@ -29,12 +26,10 @@ import org.spekframework.spek2.style.specification.describe
 import testhelper.*
 import testhelper.UserConstants.ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER
 import testhelper.UserConstants.PERSONIDENTNUMBER_DEFAULT
-import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
 import testhelper.generator.*
 import testhelper.mock.toHistoricalPersonIdentNumber
 import java.time.Duration
 import java.time.LocalDate
-import java.util.*
 
 class KafkaSyketilfelleBitConsumerSpek : Spek({
     val objectMapper: ObjectMapper = configuredJacksonMapper()
@@ -57,22 +52,6 @@ class KafkaSyketilfelleBitConsumerSpek : Spek({
             oppfolgingstilfelleBitService = oppfolgingstilfelleBitService,
         )
         val personIdentDefault = PERSONIDENTNUMBER_DEFAULT.toHistoricalPersonIdentNumber()
-
-        val oppfolgingstilfelleBit = OppfolgingstilfelleBit(
-            uuid = UUID.randomUUID(),
-            personIdentNumber = personIdentDefault,
-            virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT.value,
-            createdAt = nowUTC(),
-            inntruffet = nowUTC().minusDays(1),
-            fom = LocalDate.now().minusDays(1),
-            tom = LocalDate.now().plusDays(1),
-            tagList = listOf(
-                Tag.SYKEPENGESOKNAD,
-                Tag.SENDT,
-            ),
-            ressursId = UUID.randomUUID().toString(),
-            korrigerer = null,
-        )
 
         val partition = 0
         val syketilfellebitTopicPartition = TopicPartition(
@@ -239,7 +218,7 @@ class KafkaSyketilfelleBitConsumerSpek : Spek({
                             val oppfolgingstilfelleArbeidstakerDTO: OppfolgingstilfellePersonDTO =
                                 objectMapper.readValue(response.content!!)
 
-                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo oppfolgingstilfelleBit.personIdentNumber.value
+                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo personIdentDefault.value
                             oppfolgingstilfelleArbeidstakerDTO.oppfolgingstilfelleList.size shouldBeEqualTo 1
                             val oppfolgingstilfelle = oppfolgingstilfelleArbeidstakerDTO.oppfolgingstilfelleList[0]
                             oppfolgingstilfelle.arbeidstakerAtTilfelleEnd shouldBeEqualTo true
@@ -305,7 +284,7 @@ class KafkaSyketilfelleBitConsumerSpek : Spek({
                             val oppfolgingstilfelleArbeidstakerDTO: OppfolgingstilfellePersonDTO =
                                 objectMapper.readValue(response.content!!)
 
-                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo oppfolgingstilfelleBit.personIdentNumber.value
+                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo personIdentDefault.value
                             oppfolgingstilfelleArbeidstakerDTO.oppfolgingstilfelleList.size shouldBeEqualTo 1
                             val oppfolgingstilfelle = oppfolgingstilfelleArbeidstakerDTO.oppfolgingstilfelleList[0]
                             // siden egenmeldingsbiten har blitt slettet vil fom for oppfolgingstilfellet fra
@@ -464,7 +443,7 @@ class KafkaSyketilfelleBitConsumerSpek : Spek({
                             val oppfolgingstilfelleArbeidstakerDTO: OppfolgingstilfellePersonDTO =
                                 objectMapper.readValue(response.content!!)
 
-                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo oppfolgingstilfelleBit.personIdentNumber.value
+                            oppfolgingstilfelleArbeidstakerDTO.personIdent shouldBeEqualTo personIdentDefault.value
                             oppfolgingstilfelleArbeidstakerDTO.oppfolgingstilfelleList.size shouldBeEqualTo 0
                         }
                     }

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.personhendelse.db.getDodsdato
 import org.flywaydb.core.Flyway
 import java.sql.Connection
+import java.util.UUID
 
 class TestDatabase : DatabaseInterface {
     private val pg: EmbeddedPostgres
@@ -75,5 +76,21 @@ fun DatabaseInterface.countDeletedTilfelleBit() =
         connection.prepareStatement("SELECT COUNT(*) FROM TILFELLE_BIT_DELETED").use { ps ->
             val resultSet = ps.executeQuery().also { it.next() }
             resultSet.getInt(1)
+        }
+    }
+
+const val queryGetOppfolgingstilfellebitAvbruttForTilfellebit =
+    """
+    SELECT avbrutt 
+    FROM TILFELLE_BIT_AVBRUTT a INNER JOIN TILFELLE_BIT t ON (t.id = a.tilfelle_bit_id) 
+    WHERE t.uuid=?
+    """
+
+fun DatabaseInterface.isTilfelleBitAvbrutt(tilfelleBitId: UUID): Boolean =
+    this.connection.use { connection ->
+        connection.prepareStatement(queryGetOppfolgingstilfellebitAvbruttForTilfellebit).use {
+            it.setString(1, tilfelleBitId.toString())
+            val rs = it.executeQuery()
+            if (rs.next()) rs.getBoolean(1) else false
         }
     }

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -76,6 +76,7 @@ fun testEnvironment(
         port = 6379,
         secret = "password",
     ),
+    sykmeldingStatusConsumerEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/testhelper/TestKafka.kt
+++ b/src/test/kotlin/testhelper/TestKafka.kt
@@ -2,7 +2,7 @@ package testhelper
 
 import no.nav.common.KafkaEnvironment
 import no.nav.syfo.identhendelse.kafka.PDL_AKTOR_TOPIC
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.SYKETILFELLEBIT_TOPIC
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.SYKETILFELLEBIT_TOPIC
 
 fun testKafka(
     autoStart: Boolean = false,

--- a/src/test/kotlin/testhelper/generator/KafkaSyketilfellebitGenerator.kt
+++ b/src/test/kotlin/testhelper/generator/KafkaSyketilfellebitGenerator.kt
@@ -3,10 +3,12 @@ package testhelper.generator
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.oppfolgingstilfelle.bit.domain.Tag
-import no.nav.syfo.oppfolgingstilfelle.bit.kafka.KafkaSyketilfellebit
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.statusendring.*
+import no.nav.syfo.oppfolgingstilfelle.bit.kafka.syketilfelle.KafkaSyketilfellebit
 import no.nav.syfo.util.nowUTC
 import testhelper.UserConstants
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.*
 
 fun generateKafkaSyketilfellebitRelevantVirksomhet(
@@ -108,4 +110,21 @@ fun generateKafkaSyketilfellebitEgenmelding(
         Tag.SENDT,
         Tag.EGENMELDING,
     ).map { tag -> tag.name },
+)
+
+fun generateKafkaStatusendring(
+    sykmeldingId: UUID,
+    personIdentNumber: PersonIdentNumber = UserConstants.PERSONIDENTNUMBER_DEFAULT,
+) = SykmeldingStatusKafkaMessageDTO(
+    kafkaMetadata = KafkaMetadataDTO(
+        sykmeldingId = sykmeldingId.toString(),
+        timestamp = OffsetDateTime.now(),
+        fnr = personIdentNumber.value,
+        source = "",
+    ),
+    event = SykmeldingStatusKafkaEventDTO(
+        sykmeldingId = sykmeldingId.toString(),
+        timestamp = OffsetDateTime.now(),
+        statusEvent = STATUS_AVBRUTT,
+    ),
 )


### PR DESCRIPTION
I denne PR'en leses bare statusendringene, og avbrutte tilfellebiter lagres dersom de ikke er for gamle og gjelder en tilfellebit som finnes. Togglet av i prod i første omgang.

I neste PR tilpasses beregningen av oppfolgingstilfelle slik at avbrutte biter ikke telles med.
