### PR TITLE
IS-1864: Unngå negative varigheter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfellePerson.kt
@@ -37,7 +37,7 @@ fun List<Oppfolgingstilfelle>?.toOppfolgingstilfellePersonDTO(
     personIdent: PersonIdentNumber,
     dodsdato: LocalDate?,
 ) = OppfolgingstilfellePersonDTO(
-    oppfolgingstilfelleList = this?.toOppfolgingstilfelleDTOList(uuid) ?: emptyList(),
+    oppfolgingstilfelleList = this?.toOppfolgingstilfelleDTOList() ?: emptyList(),
     personIdent = personIdent.value,
     dodsdato = dodsdato,
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfellePerson.kt
@@ -10,6 +10,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
+import kotlin.math.max
 
 private const val DAYS_IN_WEEK = 7
 
@@ -36,7 +37,7 @@ fun List<Oppfolgingstilfelle>?.toOppfolgingstilfellePersonDTO(
     personIdent: PersonIdentNumber,
     dodsdato: LocalDate?,
 ) = OppfolgingstilfellePersonDTO(
-    oppfolgingstilfelleList = this?.toOppfolgingstilfelleDTOList() ?: emptyList(),
+    oppfolgingstilfelleList = this?.toOppfolgingstilfelleDTOList(uuid) ?: emptyList(),
     personIdent = personIdent.value,
     dodsdato = dodsdato,
 )
@@ -79,7 +80,8 @@ fun Oppfolgingstilfelle.calculateCurrentVarighetUker(): Int {
     } else {
         val totalVarighetDays = ChronoUnit.DAYS.between(start, end) + 1
         val ikkeSykedager = totalVarighetDays - antallSykedager
-        currentVarighetDaysBrutto - ikkeSykedager
+        val sykedagerTilIDag = currentVarighetDaysBrutto - ikkeSykedager
+        max(0, sykedagerTilIDag)
     }
     return currentVarighetDays.toInt() / DAYS_IN_WEEK
 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -1518,5 +1518,33 @@ class OppfolgingstilfelleBitSpek : Spek({
             oppfolgingstilfelle.antallSykedager shouldBeEqualTo 15
             oppfolgingstilfelle.calculateCurrentVarighetUker() shouldBeEqualTo 2
         }
+        it("should return 1 Oppfolgingstilfelle with 0 varighetUker hvis arbeidsdager i framtiden") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, SENDT, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().minusDays(5),
+                    tom = LocalDate.now(),
+                ),
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, SENDT, PERIODE, INGEN_AKTIVITET),
+                    fom = LocalDate.now().plusDays(15),
+                    tom = LocalDate.now().plusDays(20),
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 1
+            val oppfolgingstilfelle = oppfolgingstilfelleList.first()
+
+            val tilfelleDuration = oppfolgingstilfelle.start.until(oppfolgingstilfelle.end, ChronoUnit.DAYS)
+
+            tilfelleDuration shouldBeEqualTo 25
+            oppfolgingstilfelle.antallSykedager shouldBeEqualTo 12
+            oppfolgingstilfelle.calculateCurrentVarighetUker() shouldBeEqualTo 0
+        }
     }
 })


### PR DESCRIPTION
I noen hjørnetilfeller der sykmeldinger har startdato i framtiden kan det bli sånn at varigheten i uker blir negativ slik vi kalkulerer det nå. Så bedre å defaulte til 0 i disse tilfellene, og så får vi se nærmere på dem hvis det dukker opp i praksis. 