### PR TITLE
Don't count reisetilskudd as sykedag

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/domain/OppfolgingstilfelleDag.kt
@@ -140,6 +140,7 @@ fun OppfolgingstilfelleDag.isArbeidsdag() =
                     or (Tag.SYKEPENGESOKNAD and Tag.ARBEID_GJENNOPPTATT)
                     or (Tag.SYKEPENGESOKNAD and Tag.BEHANDLINGSDAGER)
                     or (Tag.SYKMELDING and Tag.BEHANDLINGSDAGER)
+                    or (Tag.SYKMELDING and Tag.REISETILSKUDD)
                 )
         }
         ?: true

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/OppfolgingstilfelleBitSpek.kt
@@ -1246,6 +1246,21 @@ class OppfolgingstilfelleBitSpek : Spek({
             oppfolgingstilfelleList.size shouldBeEqualTo 0
         }
 
+        it("should return no Oppfolgingstilfelle, if person has only reisetilskudd") {
+            val oppfolgingstilfelleBitList = listOf(
+                defaultBit.copy(
+                    createdAt = nowUTC(),
+                    inntruffet = nowUTC(),
+                    tagList = listOf(SYKMELDING, SENDT, PERIODE, REISETILSKUDD, UKJENT_AKTIVITET),
+                    fom = LocalDate.now().minusDays(18),
+                    tom = LocalDate.now(),
+                ),
+            )
+
+            val oppfolgingstilfelleList = oppfolgingstilfelleBitList.generateOppfolgingstilfelleList()
+            oppfolgingstilfelleList.size shouldBeEqualTo 0
+        }
+
         it("should return Oppfolgingstilfelle and exclude behandlingsdager from the interval") {
             val oppfolgingstilfelleBitList = listOf(
                 defaultBit.copy(


### PR DESCRIPTION
For sykmeldinger med reisetilskudd er den sykmeldte på jobb (så lenge de får reisetilskudd), derfor må vi ikke telle disse dagene som sykedager.