### PR TITLE
IS-2782: Get oppfolgingstilfeller for persons in one db-query

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleService.kt
@@ -3,10 +3,12 @@ package no.nav.syfo.oppfolgingstilfelle
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.person.database.getOppfolgingstilfellePerson
+import no.nav.syfo.oppfolgingstilfelle.person.database.getOppfolgingstilfelleMedDodsdatoForPersoner
 import no.nav.syfo.oppfolgingstilfelle.person.database.toOppfolgingstilfellePerson
 import no.nav.syfo.oppfolgingstilfelle.person.domain.Oppfolgingstilfelle
 import no.nav.syfo.personhendelse.db.getDodsdato
 import no.nav.syfo.util.tomorrow
+import java.time.LocalDate
 
 class OppfolgingstilfelleService(
     val database: DatabaseInterface,
@@ -14,17 +16,25 @@ class OppfolgingstilfelleService(
     fun getOppfolgingstilfeller(
         personIdent: PersonIdentNumber,
     ): List<Oppfolgingstilfelle> {
-        val oppfolgingstilfelleList: List<Oppfolgingstilfelle> =
-            oppfolgingstilfellePerson(
-                personIdent = personIdent,
-            )?.oppfolgingstilfelleList?.filter {
-                it.start.isBefore(tomorrow())
-            } ?: emptyList()
-        return oppfolgingstilfelleList.sortedByDescending { tilfelle -> tilfelle.start }
+        val oppfolgingstilfellePerson = oppfolgingstilfellePerson(
+            personIdent = personIdent,
+        )
+        return oppfolgingstilfellePerson?.oppfolgingstilfelleList?.sortedByTilfelleStartFutureExcluded() ?: emptyList()
     }
 
     fun getDodsdato(personIdent: PersonIdentNumber) = database.connection.use {
         it.getDodsdato(personIdent)
+    }
+
+    fun getOppfolgingstilfellerForPersoner(personIdents: List<PersonIdentNumber>): Map<PersonIdentNumber, Pair<List<Oppfolgingstilfelle>, LocalDate?>> {
+        val oppfolgingstilfellePersonerMedDodsdato = database.connection.use { connection ->
+            connection.getOppfolgingstilfelleMedDodsdatoForPersoner(personIdenter = personIdents)
+        }
+        return oppfolgingstilfellePersonerMedDodsdato.mapValues { (_, pair) ->
+            val (pOppfolgingstilfellePerson, dodsdato) = pair
+            val oppfolgingstilfelleList = pOppfolgingstilfellePerson.toOppfolgingstilfellePerson(dodsdato = dodsdato).oppfolgingstilfelleList.sortedByTilfelleStartFutureExcluded()
+            oppfolgingstilfelleList to dodsdato
+        }
     }
 
     private fun oppfolgingstilfellePerson(
@@ -36,4 +46,9 @@ class OppfolgingstilfelleService(
         val dodsdato = connection.getDodsdato(personIdent)
         oppfolgingstilfellePerson?.toOppfolgingstilfellePerson(dodsdato)
     }
+
+    private fun List<Oppfolgingstilfelle>.sortedByTilfelleStartFutureExcluded(): List<Oppfolgingstilfelle> =
+        this.filter {
+            it.start.isBefore(tomorrow())
+        }.sortedByDescending { it.start }
 }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/api/OppfolgingstilfellePersonApi.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/person/api/OppfolgingstilfellePersonApi.kt
@@ -49,16 +49,16 @@ fun Route.registerOppfolgingstilfelleApi(
                 token = token,
                 callId = callId,
             )
-
-            val oppfolgingstilfellerPersonsDTOs = personIdentsWithVeilederAccess.map {
-                val dodsdato = oppfolgingstilfelleService.getDodsdato(it)
-                oppfolgingstilfelleService.getOppfolgingstilfeller(
-                    personIdent = it,
-                ).toOppfolgingstilfellePersonDTO(
-                    personIdent = it,
+            val oppfolgingstilfellerForPersoner =
+                oppfolgingstilfelleService.getOppfolgingstilfellerForPersoner(personIdents = personIdentsWithVeilederAccess)
+            val oppfolgingstilfellerPersonsDTOs = oppfolgingstilfellerForPersoner.map { (personident, pair) ->
+                val (oppfolgingstilfelleList, dodsdato) = pair
+                oppfolgingstilfelleList.toOppfolgingstilfellePersonDTO(
+                    personIdent = personident,
                     dodsdato = dodsdato,
                 )
             }
+
             call.respond(oppfolgingstilfellerPersonsDTOs)
         }
     }

--- a/src/test/kotlin/no/nav/syfo/application/api/PodApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/api/PodApiSpek.kt
@@ -34,7 +34,6 @@ object PodApiSpek : Spek({
             }
             it("Returns true if pod is ready") {
                 with(handleRequest(HttpMethod.Get, podReadinessPath)) {
-                    println(response.status())
                     response.status()?.isSuccess() shouldBeEqualTo true
                     response.content shouldNotBeEqualTo null
                 }

--- a/src/test/kotlin/testhelper/generator/GenerateOppfolgingstilfellePerson.kt
+++ b/src/test/kotlin/testhelper/generator/GenerateOppfolgingstilfellePerson.kt
@@ -9,6 +9,7 @@ import java.util.*
 
 fun generateOppfolgingstilfellePerson(
     personIdent: PersonIdentNumber = UserConstants.PERSONIDENTNUMBER_DEFAULT,
+    antallSykedager: Int = 120,
 ) = OppfolgingstilfellePerson(
     uuid = UUID.randomUUID(),
     createdAt = nowUTC(),
@@ -18,7 +19,7 @@ fun generateOppfolgingstilfellePerson(
             arbeidstakerAtTilfelleEnd = false,
             start = LocalDate.now().minusMonths(6),
             end = LocalDate.now().minusMonths(2),
-            antallSykedager = 120,
+            antallSykedager = antallSykedager,
             virksomhetsnummerList = listOf(),
             gradertAtTilfelleEnd = false,
         )


### PR DESCRIPTION
Forsøk på å fikse sporadiske feil i isoppfolgingstilfelle i loggene - Se https://trello.com/c/fdQcI5DN/2872-channelwriteexception-i-isoppfolgingstilfelle.

Skrevet om spørringen som henter oppfolgingstilfeller for en liste av personer til å gjøre alt i én spørring mot databasen ved bruk av `personident = ANY (string_to_array(?, ','))` som vi har gjort i andre bulk-endepunkter. Håpet er at kall til endepunktet går raskere enn når man gjør én db-spørring per person.