### PR TITLE
IS-3192: Korrigere oppfølgingstilfelle (nytt forsøk)

### DIFF
--- a/src/main/resources/db/migration/V3_3__fix_long_sykmelding_again.sql
+++ b/src/main/resources/db/migration/V3_3__fix_long_sykmelding_again.sql
@@ -1,0 +1,1 @@
+update tilfelle_bit set processed=false where uuid = 'b986db8d-b1d6-417c-8e4e-2bd76f674729';


### PR DESCRIPTION
Må reprosessere siste tilfelle_bit for den aktuelle personen for at det nye oppfølgingstilfellet (med korrigert tildato) blir det som gjelder.

https://jira.adeo.no/browse/FAGSYSTEM-374288