### PR TITLE
IS-3397: Allow ismeroppfolging API access

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -61,6 +61,7 @@ spec:
         - application: isdialogmotekandidat
         - application: syfomodiaperson
         - application: isbehandlerdialog
+        - application: ismeroppfolging
         - application: meroppfolging-backend
           namespace: team-esyfo
         - application: amt-deltaker

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -61,6 +61,7 @@ spec:
         - application: isdialogmotekandidat
         - application: syfomodiaperson
         - application: isbehandlerdialog
+        - application: ismeroppfolging
         - application: meroppfolging-backend
           namespace: team-esyfo
         - application: amt-deltaker


### PR DESCRIPTION
Dette trengs for å spørre isoppfolgingstilfelle om nå-tilstanden på en sykmeldt på stoppunktsdatoen. Det er viktig å sjekke at personen fortsatt er sykmeldt på det gitte tidspunktet, i tillegg til om de er sykmeldt fra en virksomhet eller ikke. Skal bruke system-APIet til dette.