### PR TITLE
IS-3443: Slette feilregistrert oppfolgingstilfelle

### DIFF
--- a/src/main/resources/db/migration/V3_5__delete_incorrect_oppfolgingstilfelle.sql
+++ b/src/main/resources/db/migration/V3_5__delete_incorrect_oppfolgingstilfelle.sql
@@ -1,0 +1,2 @@
+delete from oppfolgingstilfelle_person where uuid='ea8f6b9b-be7e-4544-9337-84804b92ff50';
+delete from oppfolgingstilfelle_person where uuid='2fc5b17e-27d1-4380-a79d-5c3ecf1c8557';


### PR DESCRIPTION
Rydder opp etter en feilregistrert sykmelding (se Trello/Jira-sak).

tilfelle_bit'ene ble automatisk flyttet til `tilfelle_bit_deleted` da tombstone'n ble prosessert fra Kafka. Men siden det ikke fantes noen tidligere biter ble forekomstene i `oppfolgingstilfelle_person` liggende igjen. Sletter dem med et sql-script.