### PR TITLE
IS-3953: Tilpasser shutdown hook

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -37,7 +37,6 @@ import redis.clients.jedis.DefaultJedisClientConfig
 import redis.clients.jedis.HostAndPort
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
-import java.util.concurrent.TimeUnit
 
 const val applicationPort = 8080
 

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -192,7 +192,7 @@ fun main() {
 
     Runtime.getRuntime().addShutdownHook(
         Thread {
-            server.stop(10, 10, TimeUnit.SECONDS)
+            applicationState.ready = false
         }
     )
 


### PR DESCRIPTION
Unngå race condition ved at to tråder kaller `server.stop` omtrent samtidig. 

Sette `ready` til false slik at api'er og cronjob'er/kafke-consumers stopper.