### PR TITLE
IS-3807: Lagre kandidater for oversending til Modia/AO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -184,6 +184,7 @@ fun main() {
                     oppfolgingstilfellePersonService = oppfolgingstilfellePersonService,
                     tilfellebitRepository = tilfellebitRepository,
                     valkeyStore = valkeyStore,
+                    pdlClient = pdlClient,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/domain/Oppfolgingstilfellebit.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Oppfolgingstilfellebit.kt
@@ -224,6 +224,8 @@ fun OppfolgingstilfelleBit.isSykmeldingNy(): Boolean = this.tagList in (Tag.SYKM
 fun OppfolgingstilfelleBit.isInntektsmelding(): Boolean =
     this.tagList in (Tag.INNTEKTSMELDING and Tag.ARBEIDSGIVERPERIODE)
 
+fun OppfolgingstilfelleBit.isSykmeldingBekreftet(): Boolean = this.tagList in (Tag.SYKMELDING and Tag.BEKREFTET)
+
 fun OppfolgingstilfelleBit.isArbeidsdag() =
     this.tagList in (
         (Tag.SYKMELDING and Tag.PERIODE and Tag.FULL_AKTIVITET)

--- a/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
@@ -12,6 +12,8 @@ enum class KandidatStatus {
     FERDIG,
 }
 
+const val DAYS_AFTER_TILFELLE_START = 28L
+
 data class SykmeldtUtenArbeidsgiverKandidat(
     val uuid: UUID,
     val personident: PersonIdentNumber,
@@ -42,6 +44,6 @@ data class SykmeldtUtenArbeidsgiverKandidat(
 
 private fun calculatePlannedProcessingTime(tilfelleStart: LocalDate): OffsetDateTime {
     val now = nowUTC()
-    val processAt = tilfelleStart.plusDays(28).atStartOfDay(ZoneId.of("Europe/Oslo")).toOffsetDateTime()
+    val processAt = tilfelleStart.plusDays(DAYS_AFTER_TILFELLE_START).atStartOfDay(ZoneId.of("Europe/Oslo")).toOffsetDateTime()
     return if (now.isBefore(processAt)) processAt else now
 }

--- a/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
@@ -14,7 +14,7 @@ enum class KandidatStatus {
 
 data class SykmeldtUtenArbeidsgiverKandidat(
     val uuid: UUID,
-    val personIdentNumber: PersonIdentNumber,
+    val personident: PersonIdentNumber,
     val aktorId: String,
     val referanseId: String?,
     val createdAt: OffsetDateTime,
@@ -23,22 +23,25 @@ data class SykmeldtUtenArbeidsgiverKandidat(
 ) {
     companion object {
         fun opprett(
-            personIdentNumber: PersonIdentNumber,
+            personident: PersonIdentNumber,
             aktorId: String,
             referanseId: String?,
             tilfelleStart: LocalDate,
-        ): SykmeldtUtenArbeidsgiverKandidat {
-            val now = nowUTC()
-            val processAt28 = tilfelleStart.plusDays(28).atStartOfDay(ZoneId.of("Europe/Oslo")).toOffsetDateTime()
-            return SykmeldtUtenArbeidsgiverKandidat(
+        ) =
+            SykmeldtUtenArbeidsgiverKandidat(
                 uuid = UUID.randomUUID(),
-                personIdentNumber = personIdentNumber,
+                personident = personident,
                 aktorId = aktorId,
                 referanseId = referanseId,
-                createdAt = now,
+                createdAt = nowUTC(),
                 status = KandidatStatus.NY,
-                nextProcessingAt = if (now.isBefore(processAt28)) processAt28 else now,
+                nextProcessingAt = calculatePlannedProcessingTime(tilfelleStart),
             )
-        }
     }
+}
+
+private fun calculatePlannedProcessingTime(tilfelleStart: LocalDate): OffsetDateTime {
+    val now = nowUTC()
+    val processAt = tilfelleStart.plusDays(28).atStartOfDay(ZoneId.of("Europe/Oslo")).toOffsetDateTime()
+    return if (now.isBefore(processAt)) processAt else now
 }

--- a/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.domain
+
+import no.nav.syfo.util.nowUTC
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.util.*
+
+enum class KandidatStatus {
+    NY,
+    UTSATT,
+    FERDIG,
+}
+
+data class SykmeldtUtenArbeidsgiverKandidat(
+    val uuid: UUID,
+    val personIdentNumber: PersonIdentNumber,
+    val aktorId: String,
+    val referanseId: String?,
+    val createdAt: OffsetDateTime,
+    val status: KandidatStatus,
+    val nextProcessingAt: OffsetDateTime,
+) {
+    companion object {
+        fun opprett(
+            personIdentNumber: PersonIdentNumber,
+            aktorId: String,
+            referanseId: String?,
+            tilfelleStart: LocalDate,
+        ): SykmeldtUtenArbeidsgiverKandidat {
+            val now = nowUTC()
+            val processAt28 = tilfelleStart.plusDays(28).atStartOfDay(ZoneId.of("Europe/Oslo")).toOffsetDateTime()
+            return SykmeldtUtenArbeidsgiverKandidat(
+                uuid = UUID.randomUUID(),
+                personIdentNumber = personIdentNumber,
+                aktorId = aktorId,
+                referanseId = referanseId,
+                createdAt = now,
+                status = KandidatStatus.NY,
+                nextProcessingAt = if (now.isBefore(processAt28)) processAt28 else now,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlClient.kt
@@ -36,6 +36,7 @@ class PdlClient(
                 historikk = true,
                 grupper = listOf(
                     IdentType.FOLKEREGISTERIDENT.name,
+                    IdentType.AKTORID.name,
                 ),
             ),
         )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/pdl/PdlIdenterResponse.kt
@@ -18,6 +18,10 @@ data class PdlIdenter(
         it.gruppe == IdentType.FOLKEREGISTERIDENT.name && !it.historisk
     }?.ident
 
+    val aktivAktorId: String? = identer.firstOrNull {
+        it.gruppe == IdentType.AKTORID.name && !it.historisk
+    }?.ident
+
     fun identhendelseIsNotHistorisk(newIdent: String): Boolean {
         return identer.none { it.ident == newIdent && it.historisk }
     }
@@ -31,6 +35,7 @@ data class PdlIdent(
 
 enum class IdentType {
     FOLKEREGISTERIDENT,
+    AKTORID,
 }
 
 fun PdlIdenter.toPersonIdentNumberList(): List<PersonIdentNumber> =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -7,7 +7,9 @@ import no.nav.syfo.application.OppfolgingstilfellePersonService
 import no.nav.syfo.infrastructure.client.ArbeidsforholdClient
 import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.client.leaderelection.LeaderPodClient
+import no.nav.syfo.infrastructure.client.pdl.PdlClient
 import no.nav.syfo.infrastructure.database.DatabaseInterface
+import no.nav.syfo.infrastructure.database.SykmeldtUtenArbeidsgiverKandidatRepository
 import no.nav.syfo.infrastructure.database.bit.TilfellebitRepository
 import no.nav.syfo.launchBackgroundTask
 
@@ -18,6 +20,7 @@ fun launchCronjobModule(
     oppfolgingstilfellePersonService: OppfolgingstilfellePersonService,
     tilfellebitRepository: TilfellebitRepository,
     valkeyStore: ValkeyStore,
+    pdlClient: PdlClient,
 ) {
     val leaderPodClient = LeaderPodClient(
         electorPath = environment.electorPath
@@ -34,6 +37,7 @@ fun launchCronjobModule(
         azureAdClient = azureAdClient,
         clientEnvironment = environment.clients.arbeidsforhold,
     )
+    val kandidatRepository = SykmeldtUtenArbeidsgiverKandidatRepository(database = database)
     val sykmeldingNyCronjob = SykmeldingNyCronjob(
         database = database,
         arbeidsforholdClient = arbeidsforholdClient,
@@ -43,6 +47,8 @@ fun launchCronjobModule(
     val oppfolgingstilfelleCronjob = OppfolgingstilfelleCronjob(
         oppfolgingstilfellePersonService = oppfolgingstilfellePersonService,
         tilfellebitRepository = tilfellebitRepository,
+        pdlClient = pdlClient,
+        kandidatRepository = kandidatRepository,
         intervalDelayMinutes = environment.oppfolgingstilfelleCronjobIntervalDelayMinutes,
     )
     launchBackgroundTask(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
@@ -54,7 +54,7 @@ class OppfolgingstilfelleCronjob(
 
                 lagreBekreftetKandidatHvisAktuelt(
                     incomingBit = oppfolgingstilfelleBit,
-                    allBitsForPerson = oppfolgingstilfelleBitForPersonList,
+                    alleBiterForPerson = oppfolgingstilfelleBitForPersonList,
                 )
 
                 result.updated++
@@ -67,11 +67,11 @@ class OppfolgingstilfelleCronjob(
 
     private suspend fun lagreBekreftetKandidatHvisAktuelt(
         incomingBit: OppfolgingstilfelleBit,
-        allBitsForPerson: List<OppfolgingstilfelleBit>,
+        alleBiterForPerson: List<OppfolgingstilfelleBit>,
     ) {
         if (!incomingBit.isSykmeldingBekreftet()) return
 
-        val latestTilfelle = allBitsForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
+        val latestTilfelle = alleBiterForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
 
         // Ignore if tilfelle is not current
         if (latestTilfelle.end.isBefore(LocalDate.now())) return
@@ -88,7 +88,7 @@ class OppfolgingstilfelleCronjob(
         }
 
         val kandidat = SykmeldtUtenArbeidsgiverKandidat.opprett(
-            personIdentNumber = incomingBit.personIdentNumber,
+            personident = incomingBit.personIdentNumber,
             aktorId = aktorId,
             referanseId = incomingBit.ressursId,
             tilfelleStart = latestTilfelle.start,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
@@ -69,32 +69,36 @@ class OppfolgingstilfelleCronjob(
         incomingBit: OppfolgingstilfelleBit,
         alleBiterForPerson: List<OppfolgingstilfelleBit>,
     ) {
-        if (!incomingBit.isSykmeldingBekreftet()) return
+        try {
+            if (!incomingBit.isSykmeldingBekreftet()) return
 
-        val latestTilfelle = alleBiterForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
+            val latestTilfelle = alleBiterForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
 
-        // Ignore if tilfelle is not current
-        if (latestTilfelle.end.isBefore(LocalDate.now())) return
+            // Ignore if tilfelle is not current
+            if (latestTilfelle.end.isBefore(LocalDate.now())) return
 
-        // Ignore incomingBit if not the latest bit in tilfelle
-        if (latestTilfelle.end != incomingBit.tom) return
+            // Ignore incomingBit if not the latest bit in tilfelle
+            if (latestTilfelle.end != incomingBit.tom) return
 
-        // Maybe redundant (since BEKREFTET)?
-        if (latestTilfelle.arbeidstakerAtTilfelleEnd) return
+            // Maybe redundant (since BEKREFTET)?
+            if (latestTilfelle.arbeidstakerAtTilfelleEnd) return
 
-        val aktorId = pdlClient.pdlIdenter(incomingBit.personIdentNumber)?.hentIdenter?.aktivAktorId ?: run {
-            log.warn("Fant ikke aktorId i PDL for BEKREFTET kandidat, hopper over")
-            return
+            val aktorId = pdlClient.pdlIdenter(incomingBit.personIdentNumber)?.hentIdenter?.aktivAktorId ?: run {
+                log.warn("Fant ikke aktorId i PDL for BEKREFTET kandidat, hopper over")
+                return
+            }
+
+            val kandidat = SykmeldtUtenArbeidsgiverKandidat.opprett(
+                personident = incomingBit.personIdentNumber,
+                aktorId = aktorId,
+                referanseId = incomingBit.ressursId,
+                tilfelleStart = latestTilfelle.start,
+            )
+            kandidatRepository.createIfMissing(kandidat)
+            log.info("Opprettet BEKREFTET kandidat uten arbeidsgiver")
+        } catch (exc: Exception) {
+            log.error("Failed to process SykmeldtUtenArbeidsgiverKandidat for tilfellebit: ${incomingBit.uuid}", exc)
         }
-
-        val kandidat = SykmeldtUtenArbeidsgiverKandidat.opprett(
-            personident = incomingBit.personIdentNumber,
-            aktorId = aktorId,
-            referanseId = incomingBit.ressursId,
-            tilfelleStart = latestTilfelle.start,
-        )
-        kandidatRepository.createIfMissing(kandidat)
-        log.info("Opprettet BEKREFTET kandidat uten arbeidsgiver")
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
@@ -2,13 +2,22 @@ package no.nav.syfo.infrastructure.cronjob
 
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.application.OppfolgingstilfellePersonService
+import no.nav.syfo.domain.OppfolgingstilfelleBit
+import no.nav.syfo.domain.SykmeldtUtenArbeidsgiverKandidat
+import no.nav.syfo.domain.generateOppfolgingstilfelleList
+import no.nav.syfo.domain.isSykmeldingBekreftet
+import no.nav.syfo.infrastructure.client.pdl.PdlClient
+import no.nav.syfo.infrastructure.database.SykmeldtUtenArbeidsgiverKandidatRepository
 import no.nav.syfo.infrastructure.database.bit.TilfellebitRepository
 import no.nav.syfo.infrastructure.database.bit.toOppfolgingstilfelleBitList
 import org.slf4j.LoggerFactory
+import java.time.LocalDate
 
 class OppfolgingstilfelleCronjob(
     private val oppfolgingstilfellePersonService: OppfolgingstilfellePersonService,
     private val tilfellebitRepository: TilfellebitRepository,
+    private val pdlClient: PdlClient,
+    private val kandidatRepository: SykmeldtUtenArbeidsgiverKandidatRepository,
     override val intervalDelayMinutes: Long = 10,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 2
@@ -22,7 +31,7 @@ class OppfolgingstilfelleCronjob(
         )
     }
 
-    fun runJob() = CronjobResult().also { result ->
+    suspend fun runJob() = CronjobResult().also { result ->
         val unprocessed = tilfellebitRepository.getUnprocessedOppfolgingstilfelleBitList().toOppfolgingstilfelleBitList()
         unprocessed.forEach { oppfolgingstilfelleBit ->
             try {
@@ -42,12 +51,50 @@ class OppfolgingstilfelleCronjob(
                     oppfolgingstilfelleBitForPersonList = oppfolgingstilfelleBitForPersonList,
                 )
                 tilfellebitRepository.setProcessedOppfolgingstilfelleBit(oppfolgingstilfelleBit.uuid)
+
+                lagreBekreftetKandidatHvisAktuelt(
+                    incomingBit = oppfolgingstilfelleBit,
+                    allBitsForPerson = oppfolgingstilfelleBitForPersonList,
+                )
+
                 result.updated++
             } catch (exc: Exception) {
                 log.error("caught exception when processing oppfolgingstilfelleBit", exc)
                 result.failed++
             }
         }
+    }
+
+    private suspend fun lagreBekreftetKandidatHvisAktuelt(
+        incomingBit: OppfolgingstilfelleBit,
+        allBitsForPerson: List<OppfolgingstilfelleBit>,
+    ) {
+        if (!incomingBit.isSykmeldingBekreftet()) return
+
+        val latestTilfelle = allBitsForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
+
+        // Ignore if tilfelle is not current
+        if (latestTilfelle.end.isBefore(LocalDate.now())) return
+
+        // Ignore incomingBit if not the latest bit in tilfelle
+        if (latestTilfelle.end != incomingBit.tom) return
+
+        // Maybe redundant (since BEKREFTET)?
+        if (latestTilfelle.arbeidstakerAtTilfelleEnd) return
+
+        val aktorId = pdlClient.pdlIdenter(incomingBit.personIdentNumber)?.hentIdenter?.aktivAktorId ?: run {
+            log.warn("Fant ikke aktorId i PDL for BEKREFTET kandidat, hopper over")
+            return
+        }
+
+        val kandidat = SykmeldtUtenArbeidsgiverKandidat.opprett(
+            personIdentNumber = incomingBit.personIdentNumber,
+            aktorId = aktorId,
+            referanseId = incomingBit.ressursId,
+            tilfelleStart = latestTilfelle.start,
+        )
+        kandidatRepository.createIfMissing(kandidat)
+        log.info("Opprettet BEKREFTET kandidat uten arbeidsgiver")
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
@@ -1,0 +1,41 @@
+package no.nav.syfo.infrastructure.database
+
+import no.nav.syfo.domain.KandidatStatus
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.SykmeldtUtenArbeidsgiverKandidat
+import no.nav.syfo.util.toOffsetDateTimeUTC
+import java.sql.ResultSet
+import java.time.OffsetDateTime
+import java.util.*
+
+data class PSykmeldtUtenArbeidsgiverKandidat(
+    val id: Int,
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val personident: String,
+    val aktorId: String,
+    val referanseId: String?,
+    val status: String,
+    val nextProcessingAt: OffsetDateTime,
+)
+
+fun ResultSet.toPSykmeldtUtenArbeidsgiverKandidat() = PSykmeldtUtenArbeidsgiverKandidat(
+    id = getInt("id"),
+    uuid = UUID.fromString(getString("uuid")),
+    createdAt = getTimestamp("created_at").toOffsetDateTimeUTC(),
+    personident = getString("personident"),
+    aktorId = getString("aktor_id"),
+    referanseId = getString("referanse_id"),
+    status = getString("status"),
+    nextProcessingAt = getTimestamp("next_processing_at").toOffsetDateTimeUTC(),
+)
+
+fun PSykmeldtUtenArbeidsgiverKandidat.toKandidat() = SykmeldtUtenArbeidsgiverKandidat(
+    uuid = uuid,
+    personIdentNumber = PersonIdentNumber(personident),
+    aktorId = aktorId,
+    referanseId = referanseId,
+    createdAt = createdAt,
+    status = KandidatStatus.valueOf(status),
+    nextProcessingAt = nextProcessingAt,
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
@@ -32,7 +32,7 @@ fun ResultSet.toPSykmeldtUtenArbeidsgiverKandidat() = PSykmeldtUtenArbeidsgiverK
 
 fun PSykmeldtUtenArbeidsgiverKandidat.toKandidat() = SykmeldtUtenArbeidsgiverKandidat(
     uuid = uuid,
-    personIdentNumber = PersonIdentNumber(personident),
+    personident = PersonIdentNumber(personident),
     aktorId = aktorId,
     referanseId = referanseId,
     createdAt = createdAt,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.infrastructure.database
+
+import no.nav.syfo.domain.SykmeldtUtenArbeidsgiverKandidat
+import java.sql.Timestamp
+
+class SykmeldtUtenArbeidsgiverKandidatRepository(private val database: DatabaseInterface) {
+
+    /**
+     * Oppretter kandidaten hvis det ikke allerede finnes en aktiv (NY/UTSATT) kandidat for personen.
+     */
+    fun createIfMissing(kandidat: SykmeldtUtenArbeidsgiverKandidat) {
+        database.connection.use { connection ->
+            val hasActive = connection.prepareStatement(QUERY_GET_ACTIVE_KANDIDAT).use {
+                it.setString(1, kandidat.personIdentNumber.value)
+                it.executeQuery().next()
+            }
+            if (!hasActive) {
+                connection.prepareStatement(QUERY_INSERT_KANDIDAT).use {
+                    it.setString(1, kandidat.uuid.toString())
+                    it.setTimestamp(2, Timestamp.from(kandidat.createdAt.toInstant()))
+                    it.setString(3, kandidat.personIdentNumber.value)
+                    it.setString(4, kandidat.aktorId)
+                    it.setString(5, kandidat.referanseId)
+                    it.setString(6, kandidat.status.name)
+                    it.setTimestamp(7, Timestamp.from(kandidat.nextProcessingAt.toInstant()))
+                    it.executeUpdate()
+                }
+                connection.commit()
+            }
+        }
+    }
+
+    companion object {
+        private val QUERY_GET_ACTIVE_KANDIDAT =
+            """
+            SELECT id FROM KANDIDAT_UTEN_ARBEIDSGIVER
+            WHERE personident = ?
+            AND status IN ('NY', 'UTSATT')
+            """
+
+        private const val QUERY_INSERT_KANDIDAT =
+            """
+            INSERT INTO KANDIDAT_UTEN_ARBEIDSGIVER (
+                uuid, created_at, personident, aktor_id, referanse_id, status, next_processing_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
@@ -11,14 +11,14 @@ class SykmeldtUtenArbeidsgiverKandidatRepository(private val database: DatabaseI
     fun createIfMissing(kandidat: SykmeldtUtenArbeidsgiverKandidat) {
         database.connection.use { connection ->
             val hasActive = connection.prepareStatement(QUERY_GET_ACTIVE_KANDIDAT).use {
-                it.setString(1, kandidat.personIdentNumber.value)
+                it.setString(1, kandidat.personident.value)
                 it.executeQuery().next()
             }
             if (!hasActive) {
                 connection.prepareStatement(QUERY_INSERT_KANDIDAT).use {
                     it.setString(1, kandidat.uuid.toString())
                     it.setTimestamp(2, Timestamp.from(kandidat.createdAt.toInstant()))
-                    it.setString(3, kandidat.personIdentNumber.value)
+                    it.setString(3, kandidat.personident.value)
                     it.setString(4, kandidat.aktorId)
                     it.setString(5, kandidat.referanseId)
                     it.setString(6, kandidat.status.name)

--- a/src/main/resources/db/migration/V3_9__create_table_kandidat_uten_arbeidsgiver.sql
+++ b/src/main/resources/db/migration/V3_9__create_table_kandidat_uten_arbeidsgiver.sql
@@ -1,0 +1,14 @@
+CREATE TABLE KANDIDAT_UTEN_ARBEIDSGIVER
+(
+    id                  SERIAL          PRIMARY KEY,
+    uuid                CHAR(36)        NOT NULL UNIQUE,
+    created_at          timestamptz     NOT NULL,
+    personident         CHAR(11)        NOT NULL,
+    aktor_id            VARCHAR(20)     NOT NULL,
+    referanse_id        VARCHAR(50),
+    status              VARCHAR(10)     NOT NULL,
+    next_processing_at  timestamptz     NOT NULL
+);
+
+CREATE INDEX IX_KANDIDAT_UTEN_ARBEIDSGIVER_PERSONIDENT ON KANDIDAT_UTEN_ARBEIDSGIVER (personident);
+CREATE INDEX IX_KANDIDAT_UTEN_ARBEIDSGIVER_STATUS_NEXT ON KANDIDAT_UTEN_ARBEIDSGIVER (status, next_processing_at);

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
@@ -61,8 +61,8 @@ class OppfolgingstilfelleCronjobKandidatTest {
         justRun { oppfolgingstilfellePersonProducer.sendOppfolgingstilfellePerson(any()) }
     }
 
-    private fun pollAndRun(bits: List<KafkaSyketilfellebit>) {
-        val records = bits.mapIndexed { i, bit ->
+    private fun pollAndRun(biter: List<KafkaSyketilfellebit>) {
+        val records = biter.mapIndexed { i, bit ->
             ConsumerRecord(SYKETILFELLEBIT_TOPIC, 0, i.toLong(), bit.id, bit)
         }
         every { mockKafkaConsumer.poll(any<Duration>()) } returns ConsumerRecords(

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
@@ -1,0 +1,183 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.OppfolgingstilfelleBitService
+import no.nav.syfo.application.OppfolgingstilfellePersonService
+import no.nav.syfo.domain.Tag
+import no.nav.syfo.infrastructure.kafka.OppfolgingstilfellePersonProducer
+import no.nav.syfo.infrastructure.kafka.syketilfelle.KafkaSyketilfellebit
+import no.nav.syfo.infrastructure.kafka.syketilfelle.SYKETILFELLEBIT_TOPIC
+import no.nav.syfo.infrastructure.kafka.syketilfelle.SyketilfellebitConsumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelper.ExternalMockEnvironment
+import testhelper.UserConstants.PERSONIDENTNUMBER_DEFAULT
+import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
+import testhelper.countKandidater
+import testhelper.dropData
+import testhelper.generator.generateKafkaSyketilfellebitRelevantSykmeldingBekreftet
+import testhelper.mock.toHistoricalPersonIdentNumber
+import java.time.Duration
+import java.time.LocalDate
+
+class OppfolgingstilfelleCronjobKandidatTest {
+
+    private val externalMockEnvironment = ExternalMockEnvironment.instance
+    private val database = externalMockEnvironment.database
+    private val tilfellebitRepository = externalMockEnvironment.tilfellebitRepository
+    private val kandidatRepository = externalMockEnvironment.kandidatRepository
+
+    private val personIdentDefault = PERSONIDENTNUMBER_DEFAULT.toHistoricalPersonIdentNumber()
+    private val topicPartition = TopicPartition(SYKETILFELLEBIT_TOPIC, 0)
+
+    private val mockKafkaConsumer = mockk<KafkaConsumer<String, KafkaSyketilfellebit>>()
+    private val oppfolgingstilfellePersonProducer = mockk<OppfolgingstilfellePersonProducer>()
+
+    private val kafkaSyketilfellebitService = SyketilfellebitConsumer(
+        oppfolgingstilfelleBitService = OppfolgingstilfelleBitService(tilfellebitRepository),
+    )
+    private val oppfolgingstilfelleCronjob = OppfolgingstilfelleCronjob(
+        oppfolgingstilfellePersonService = OppfolgingstilfellePersonService(
+            oppfolgingstilfellePersonRepository = externalMockEnvironment.oppfolgingstilfellePersonRepository,
+            oppfolgingstilfellePersonProducer = oppfolgingstilfellePersonProducer,
+        ),
+        tilfellebitRepository = tilfellebitRepository,
+        pdlClient = externalMockEnvironment.pdlClient,
+        kandidatRepository = kandidatRepository,
+    )
+
+    @BeforeEach
+    fun beforeEach() {
+        database.dropData()
+        clearMocks(mockKafkaConsumer)
+        every { mockKafkaConsumer.commitSync() } returns Unit
+        clearMocks(oppfolgingstilfellePersonProducer)
+        justRun { oppfolgingstilfellePersonProducer.sendOppfolgingstilfellePerson(any()) }
+    }
+
+    private fun pollAndRun(bits: List<KafkaSyketilfellebit>) {
+        val records = bits.mapIndexed { i, bit ->
+            ConsumerRecord(SYKETILFELLEBIT_TOPIC, 0, i.toLong(), bit.id, bit)
+        }
+        every { mockKafkaConsumer.poll(any<Duration>()) } returns ConsumerRecords(
+            mapOf(topicPartition to records)
+        )
+        kafkaSyketilfellebitService.pollAndProcessRecords(consumer = mockKafkaConsumer)
+        runBlocking { oppfolgingstilfelleCronjob.runJob() }
+    }
+
+    @Test
+    fun `stores kandidat when BEKREFTET bit has active tilfelle at least 28 days old`() {
+        val bit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit))
+        assertEquals(1, database.countKandidater())
+    }
+
+    @Test
+    fun `stores kandidat with future nextProcessingAt when tilfelle is under 28 days`() {
+        val bit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(10),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit))
+        assertEquals(1, database.countKandidater())
+    }
+
+    @Test
+    fun `does not store duplicate kandidat for same person`() {
+        val bit1 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit1))
+        assertEquals(1, database.countKandidater())
+
+        val bit2 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit2))
+        assertEquals(1, database.countKandidater())
+    }
+
+    @Test
+    fun `does not store kandidat for non-BEKREFTET bit`() {
+        val bit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        ).copy(tags = listOf(Tag.SYKMELDING, Tag.SENDT, Tag.PERIODE, Tag.INGEN_AKTIVITET).map { it.name })
+
+        pollAndRun(listOf(bit))
+        assertEquals(0, database.countKandidater())
+    }
+
+    @Test
+    fun `does not store kandidat when tilfelle has ended`() {
+        val bit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(40),
+            tom = LocalDate.now().minusDays(5),
+        )
+        pollAndRun(listOf(bit))
+        assertEquals(0, database.countKandidater())
+    }
+
+    @Test
+    fun `does not store kandidat when incoming bit is not at the end of the tilfelle`() {
+        // Establish a tilfelle ending today via a non-BEKREFTET bit
+        val sendtBit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        ).copy(tags = listOf(Tag.SYKMELDING, Tag.SENDT, Tag.PERIODE, Tag.INGEN_AKTIVITET).map { it.name })
+        pollAndRun(listOf(sendtBit))
+        assertEquals(0, database.countKandidater())
+
+        // Incoming BEKREFTET bit ending before the tilfelle end → not at end → skip
+        val bekreftetBit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now().minusDays(5),
+        )
+        pollAndRun(listOf(bekreftetBit))
+        assertEquals(0, database.countKandidater())
+    }
+
+    @Test
+    fun `does not store kandidat when person has employer at tilfelle end`() {
+        // A SENDT bit with virksomhetsnummer marks the tilfelle as arbeidstaker
+        val sendtBitWithEmployer = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        ).copy(
+            orgnummer = VIRKSOMHETSNUMMER_DEFAULT.value,
+            tags = listOf(Tag.SYKMELDING, Tag.SENDT, Tag.PERIODE, Tag.INGEN_AKTIVITET).map { it.name },
+        )
+        pollAndRun(listOf(sendtBitWithEmployer))
+        assertEquals(0, database.countKandidater())
+
+        // BEKREFTET bit for same period: tilfelle has arbeidstakerAtTilfelleEnd=true → skip
+        val bekreftetBit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bekreftetBit))
+        assertEquals(0, database.countKandidater())
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleApiTest.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.api.endpoints.OppfolgingstilfellePersonDTO
 import no.nav.syfo.application.OppfolgingstilfelleBitService
 import no.nav.syfo.application.OppfolgingstilfellePersonService
@@ -88,6 +89,8 @@ class OppfolgingstilfelleApiTest {
             oppfolgingstilfellePersonProducer = oppfolgingstilfellePersonProducer,
         ),
         tilfellebitRepository = tilfellebitRepository,
+        pdlClient = externalMockEnvironment.pdlClient,
+        kandidatRepository = externalMockEnvironment.kandidatRepository,
     )
     private val oppfolgingstilfelleApiV1Path = "/api/internad/v1/oppfolgingstilfelle"
     private val validToken = generateJWT(
@@ -128,7 +131,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -182,7 +185,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
                 val dodsdato = LocalDate.now().minusDays(3)
                 oppfolgingstilfellePersonRepository.createPerson(
                     uuid = UUID.randomUUID(),
@@ -225,7 +228,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -270,7 +273,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -316,7 +319,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -375,7 +378,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 2) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -462,7 +465,7 @@ class OppfolgingstilfelleApiTest {
                 syketilfellebitConsumer.pollAndProcessRecords(
                     consumer = mockKafkaConsumerSyketilfelleBit,
                 )
-                oppfolgingstilfelleCronjob.runJob()
+                runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
                 verify(exactly = 1) {
                     mockKafkaConsumerSyketilfelleBit.commitSync()

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/api/OppfolgingstilfelleSystemApiTest.kt
@@ -4,6 +4,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import no.nav.syfo.api.endpoints.oppfolgingstilfelleSystemApiPersonIdentPath
 import no.nav.syfo.api.endpoints.oppfolgingstilfelleSystemApiV1Path
 import no.nav.syfo.application.OppfolgingstilfelleBitService
@@ -72,6 +73,8 @@ class OppfolgingstilfelleSystemApiTest {
             oppfolgingstilfellePersonProducer = oppfolgingstilfellePersonProducer,
         ),
         tilfellebitRepository = tilfellebitRepository,
+        pdlClient = externalMockEnvironment.pdlClient,
+        kandidatRepository = externalMockEnvironment.kandidatRepository,
     )
 
     private val url = "$oppfolgingstilfelleSystemApiV1Path$oppfolgingstilfelleSystemApiPersonIdentPath"
@@ -108,7 +111,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             verify(exactly = 1) {
                 mockKafkaConsumerSyketilfelleBit.commitSync()
@@ -162,7 +165,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             testApplication {
                 val client = setupApiAndClient()
@@ -200,7 +203,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             testApplication {
                 val client = setupApiAndClient()
@@ -238,7 +241,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             testApplication {
                 val client = setupApiAndClient()
@@ -298,7 +301,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             testApplication {
                 val client = setupApiAndClient()
@@ -337,7 +340,7 @@ class OppfolgingstilfelleSystemApiTest {
             syketilfellebitConsumer.pollAndProcessRecords(
                 consumer = mockKafkaConsumerSyketilfelleBit,
             )
-            oppfolgingstilfelleCronjob.runJob()
+            runBlocking { oppfolgingstilfelleCronjob.runJob() }
 
             verify(exactly = 1) {
                 mockKafkaConsumerSyketilfelleBit.commitSync()

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/syketilfelle/KafkaSyketilfelleBitConsumerTest.kt
@@ -146,6 +146,8 @@ class KafkaSyketilfelleBitConsumerTest {
             oppfolgingstilfellePersonProducer = oppfolgingstilfellePersonProducer,
         ),
         tilfellebitRepository = tilfellebitRepository,
+        pdlClient = externalMockEnvironment.pdlClient,
+        kandidatRepository = externalMockEnvironment.kandidatRepository,
     )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/sykmeldingstatus/KafkaSykmeldingstatusConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/bit/kafka/sykmeldingstatus/KafkaSykmeldingstatusConsumerTest.kt
@@ -107,6 +107,8 @@ class KafkaSykmeldingstatusConsumerTest {
             oppfolgingstilfellePersonProducer = oppfolgingstilfellePersonProducer,
         ),
         tilfellebitRepository = tilfellebitRepository,
+        pdlClient = externalMockEnvironment.pdlClient,
+        kandidatRepository = externalMockEnvironment.kandidatRepository,
     )
 
     @BeforeEach

--- a/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/testhelper/ExternalMockEnvironment.kt
@@ -3,7 +3,10 @@ package testhelper
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.api.cache.ValkeyStore
 import no.nav.syfo.application.OppfolgingstilfelleService
+import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.client.pdl.PdlClient
 import no.nav.syfo.infrastructure.database.OppfolgingstilfellePersonRepository
+import no.nav.syfo.infrastructure.database.SykmeldtUtenArbeidsgiverKandidatRepository
 import no.nav.syfo.infrastructure.database.bit.TilfellebitRepository
 import redis.clients.jedis.DefaultJedisClientConfig
 import redis.clients.jedis.HostAndPort
@@ -43,6 +46,16 @@ class ExternalMockEnvironment private constructor() {
     val oppfolgingstilfellePersonRepository = OppfolgingstilfellePersonRepository(database = database)
     val tilfellebitRepository = TilfellebitRepository(database = database)
     val oppfolgingstilfelleService = OppfolgingstilfelleService(oppfolgingstilfellePersonRepository)
+    val pdlClient = PdlClient(
+        azureAdClient = AzureAdClient(
+            azureEnviroment = environment.azure,
+            valkeyStore = valkeyStore,
+            httpClient = mockHttpClient,
+        ),
+        clientEnvironment = environment.clients.pdl,
+        httpClient = mockHttpClient,
+    )
+    val kandidatRepository = SykmeldtUtenArbeidsgiverKandidatRepository(database = database)
 
     companion object {
         val instance: ExternalMockEnvironment by lazy {

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -57,6 +57,9 @@ fun DatabaseInterface.dropData() {
         """
         DELETE FROM PERSON
         """.trimIndent(),
+        """
+        DELETE FROM KANDIDAT_UTEN_ARBEIDSGIVER
+        """.trimIndent(),
     )
     this.connection.use { connection ->
         queryList.forEach { query ->
@@ -69,6 +72,14 @@ fun DatabaseInterface.dropData() {
 fun DatabaseInterface.countDeletedTilfelleBit() =
     this.connection.use { connection ->
         connection.prepareStatement("SELECT COUNT(*) FROM TILFELLE_BIT_DELETED").use { ps ->
+            val resultSet = ps.executeQuery().also { it.next() }
+            resultSet.getInt(1)
+        }
+    }
+
+fun DatabaseInterface.countKandidater() =
+    this.connection.use { connection ->
+        connection.prepareStatement("SELECT COUNT(*) FROM KANDIDAT_UTEN_ARBEIDSGIVER").use { ps ->
             val resultSet = ps.executeQuery().also { it.next() }
             resultSet.getInt(1)
         }

--- a/src/test/kotlin/testhelper/UserConstants.kt
+++ b/src/test/kotlin/testhelper/UserConstants.kt
@@ -16,6 +16,8 @@ object UserConstants {
     val ARBEIDSTAKER_3_FNR = PersonIdentNumber("12345678913")
     val ARBEIDSTAKER_4_FNR = PersonIdentNumber("12345678919")
     val ARBEIDSTAKER_WITH_ERROR = PersonIdentNumber("12345678666")
+
+    const val ARBEIDSTAKER_AKTOR_ID = "1000012345678"
     val ARBEIDSTAKER_VIRKSOMHET_NO_NARMESTELEDER = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "8"))
     val ARBEIDSTAKER_UNKNOWN_AAREG = PersonIdentNumber(ARBEIDSTAKER_FNR.value.replace("2", "9"))
 

--- a/src/test/kotlin/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/testhelper/mock/PdlMock.kt
@@ -32,6 +32,11 @@ fun generatePdlIdenterResponse(
                     historisk = true,
                     gruppe = IdentType.FOLKEREGISTERIDENT.name,
                 ),
+                PdlIdent(
+                    ident = UserConstants.ARBEIDSTAKER_AKTOR_ID,
+                    historisk = false,
+                    gruppe = IdentType.AKTORID.name,
+                ),
             ),
         ),
     ),


### PR DESCRIPTION
Dette er et utkast til hvordan vi kan gjøre dette. 

Foreløpig er det bare snakk om lagring av kandidater for oversending etter 4 uker. 

Vi kan få tilgang på hvilke kandidater Modia/AO faktisk mottar slik at vi kan sammenlikne.