### PR TITLE
IS-3989: Unngå duplikate ModiaAO-kandidater

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/OppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/OppfolgingstilfellePersonService.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.application
 
 import no.nav.syfo.domain.OppfolgingstilfelleBit
+import no.nav.syfo.domain.OppfolgingstilfellePerson
 import no.nav.syfo.domain.generateOppfolgingstilfelleList
 import no.nav.syfo.domain.hasGjentakendeSykefravar
 import no.nav.syfo.domain.toOppfolgingstilfellePerson
@@ -14,7 +15,7 @@ class OppfolgingstilfellePersonService(
     fun createOppfolgingstilfellePerson(
         oppfolgingstilfelleBit: OppfolgingstilfelleBit,
         oppfolgingstilfelleBitForPersonList: List<OppfolgingstilfelleBit>,
-    ) {
+    ): OppfolgingstilfellePerson {
         val oppfolgingstilfellePerson = oppfolgingstilfelleBit.toOppfolgingstilfellePerson(
             oppfolgingstilfelleBitList = oppfolgingstilfelleBitForPersonList,
             dodsdato = oppfolgingstilfellePersonRepository.getDodsdato(oppfolgingstilfelleBit.personIdentNumber),
@@ -28,5 +29,6 @@ class OppfolgingstilfellePersonService(
         oppfolgingstilfellePersonProducer.sendOppfolgingstilfellePerson(
             oppfolgingstilfellePerson = oppfolgingstilfellePerson
         )
+        return oppfolgingstilfellePerson
     }
 }

--- a/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SykmeldtUtenArbeidsgiverKandidat.kt
@@ -20,6 +20,7 @@ data class SykmeldtUtenArbeidsgiverKandidat(
     val aktorId: String,
     val referanseId: String?,
     val createdAt: OffsetDateTime,
+    val tilfelleStart: LocalDate,
     val status: KandidatStatus,
     val nextProcessingAt: OffsetDateTime,
 ) {
@@ -36,6 +37,7 @@ data class SykmeldtUtenArbeidsgiverKandidat(
                 aktorId = aktorId,
                 referanseId = referanseId,
                 createdAt = nowUTC(),
+                tilfelleStart = tilfelleStart,
                 status = KandidatStatus.NY,
                 nextProcessingAt = calculatePlannedProcessingTime(tilfelleStart),
             )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
@@ -54,7 +54,6 @@ class OppfolgingstilfelleCronjob(
 
                 lagreBekreftetKandidatHvisAktuell(
                     incomingBit = oppfolgingstilfelleBit,
-                    alleBiterForPerson = oppfolgingstilfelleBitForPersonList,
                     oppfolgingstilfellePerson = oppfolgingstilfellePerson,
                 )
 
@@ -68,7 +67,6 @@ class OppfolgingstilfelleCronjob(
 
     private suspend fun lagreBekreftetKandidatHvisAktuell(
         incomingBit: OppfolgingstilfelleBit,
-        alleBiterForPerson: List<OppfolgingstilfelleBit>,
         oppfolgingstilfellePerson: OppfolgingstilfellePerson,
     ) {
         try {
@@ -97,7 +95,6 @@ class OppfolgingstilfelleCronjob(
                 tilfelleStart = latestTilfelle.start,
             )
             kandidatRepository.createIfMissing(kandidat)
-            log.info("Opprettet BEKREFTET kandidat uten arbeidsgiver")
         } catch (exc: Exception) {
             log.error("Failed to process SykmeldtUtenArbeidsgiverKandidat for tilfellebit: ${incomingBit.uuid}", exc)
         }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjob.kt
@@ -3,8 +3,8 @@ package no.nav.syfo.infrastructure.cronjob
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.application.OppfolgingstilfellePersonService
 import no.nav.syfo.domain.OppfolgingstilfelleBit
+import no.nav.syfo.domain.OppfolgingstilfellePerson
 import no.nav.syfo.domain.SykmeldtUtenArbeidsgiverKandidat
-import no.nav.syfo.domain.generateOppfolgingstilfelleList
 import no.nav.syfo.domain.isSykmeldingBekreftet
 import no.nav.syfo.infrastructure.client.pdl.PdlClient
 import no.nav.syfo.infrastructure.database.SykmeldtUtenArbeidsgiverKandidatRepository
@@ -46,15 +46,16 @@ class OppfolgingstilfelleCronjob(
                     )
                 }
 
-                oppfolgingstilfellePersonService.createOppfolgingstilfellePerson(
+                val oppfolgingstilfellePerson = oppfolgingstilfellePersonService.createOppfolgingstilfellePerson(
                     oppfolgingstilfelleBit = oppfolgingstilfelleBit,
                     oppfolgingstilfelleBitForPersonList = oppfolgingstilfelleBitForPersonList,
                 )
                 tilfellebitRepository.setProcessedOppfolgingstilfelleBit(oppfolgingstilfelleBit.uuid)
 
-                lagreBekreftetKandidatHvisAktuelt(
+                lagreBekreftetKandidatHvisAktuell(
                     incomingBit = oppfolgingstilfelleBit,
                     alleBiterForPerson = oppfolgingstilfelleBitForPersonList,
+                    oppfolgingstilfellePerson = oppfolgingstilfellePerson,
                 )
 
                 result.updated++
@@ -65,14 +66,15 @@ class OppfolgingstilfelleCronjob(
         }
     }
 
-    private suspend fun lagreBekreftetKandidatHvisAktuelt(
+    private suspend fun lagreBekreftetKandidatHvisAktuell(
         incomingBit: OppfolgingstilfelleBit,
         alleBiterForPerson: List<OppfolgingstilfelleBit>,
+        oppfolgingstilfellePerson: OppfolgingstilfellePerson,
     ) {
         try {
             if (!incomingBit.isSykmeldingBekreftet()) return
 
-            val latestTilfelle = alleBiterForPerson.generateOppfolgingstilfelleList().lastOrNull() ?: return
+            val latestTilfelle = oppfolgingstilfellePerson.oppfolgingstilfelleList.lastOrNull() ?: return
 
             // Ignore if tilfelle is not current
             if (latestTilfelle.end.isBefore(LocalDate.now())) return

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PSykmeldtUtenArbeidsgiverKandidat.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.domain.SykmeldtUtenArbeidsgiverKandidat
 import no.nav.syfo.util.toOffsetDateTimeUTC
 import java.sql.ResultSet
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -15,6 +16,7 @@ data class PSykmeldtUtenArbeidsgiverKandidat(
     val personident: String,
     val aktorId: String,
     val referanseId: String?,
+    val tilfelleStart: LocalDate,
     val status: String,
     val nextProcessingAt: OffsetDateTime,
 )
@@ -26,6 +28,7 @@ fun ResultSet.toPSykmeldtUtenArbeidsgiverKandidat() = PSykmeldtUtenArbeidsgiverK
     personident = getString("personident"),
     aktorId = getString("aktor_id"),
     referanseId = getString("referanse_id"),
+    tilfelleStart = getDate("tilfelle_start").toLocalDate(),
     status = getString("status"),
     nextProcessingAt = getTimestamp("next_processing_at").toOffsetDateTimeUTC(),
 )
@@ -36,6 +39,7 @@ fun PSykmeldtUtenArbeidsgiverKandidat.toKandidat() = SykmeldtUtenArbeidsgiverKan
     aktorId = aktorId,
     referanseId = referanseId,
     createdAt = createdAt,
+    tilfelleStart = tilfelleStart,
     status = KandidatStatus.valueOf(status),
     nextProcessingAt = nextProcessingAt,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
@@ -5,9 +5,6 @@ import java.sql.Timestamp
 
 class SykmeldtUtenArbeidsgiverKandidatRepository(private val database: DatabaseInterface) {
 
-    /**
-     * Oppretter kandidaten hvis det ikke allerede finnes en aktiv (NY/UTSATT) kandidat for personen.
-     */
     fun createIfMissing(kandidat: SykmeldtUtenArbeidsgiverKandidat) {
         database.connection.use { connection ->
             val hasExisting = connection.prepareStatement(QUERY_GET_EXISTING_KANDIDAT).use {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/SykmeldtUtenArbeidsgiverKandidatRepository.kt
@@ -10,19 +10,21 @@ class SykmeldtUtenArbeidsgiverKandidatRepository(private val database: DatabaseI
      */
     fun createIfMissing(kandidat: SykmeldtUtenArbeidsgiverKandidat) {
         database.connection.use { connection ->
-            val hasActive = connection.prepareStatement(QUERY_GET_ACTIVE_KANDIDAT).use {
+            val hasExisting = connection.prepareStatement(QUERY_GET_EXISTING_KANDIDAT).use {
                 it.setString(1, kandidat.personident.value)
+                it.setObject(2, kandidat.tilfelleStart)
                 it.executeQuery().next()
             }
-            if (!hasActive) {
+            if (!hasExisting) {
                 connection.prepareStatement(QUERY_INSERT_KANDIDAT).use {
                     it.setString(1, kandidat.uuid.toString())
                     it.setTimestamp(2, Timestamp.from(kandidat.createdAt.toInstant()))
                     it.setString(3, kandidat.personident.value)
                     it.setString(4, kandidat.aktorId)
                     it.setString(5, kandidat.referanseId)
-                    it.setString(6, kandidat.status.name)
-                    it.setTimestamp(7, Timestamp.from(kandidat.nextProcessingAt.toInstant()))
+                    it.setObject(6, kandidat.tilfelleStart)
+                    it.setString(7, kandidat.status.name)
+                    it.setTimestamp(8, Timestamp.from(kandidat.nextProcessingAt.toInstant()))
                     it.executeUpdate()
                 }
                 connection.commit()
@@ -31,18 +33,18 @@ class SykmeldtUtenArbeidsgiverKandidatRepository(private val database: DatabaseI
     }
 
     companion object {
-        private val QUERY_GET_ACTIVE_KANDIDAT =
+        private val QUERY_GET_EXISTING_KANDIDAT =
             """
             SELECT id FROM KANDIDAT_UTEN_ARBEIDSGIVER
             WHERE personident = ?
-            AND status IN ('NY', 'UTSATT')
+            AND tilfelle_start = ?
             """
 
         private const val QUERY_INSERT_KANDIDAT =
             """
             INSERT INTO KANDIDAT_UTEN_ARBEIDSGIVER (
-                uuid, created_at, personident, aktor_id, referanse_id, status, next_processing_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                uuid, created_at, personident, aktor_id, referanse_id, tilfelle_start, status, next_processing_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """
     }
 }

--- a/src/main/resources/db/migration/V4_0__alter_table_kandidat_uten_arbeidsgiver_add_tilfelle_start.sql
+++ b/src/main/resources/db/migration/V4_0__alter_table_kandidat_uten_arbeidsgiver_add_tilfelle_start.sql
@@ -1,0 +1,20 @@
+ALTER TABLE KANDIDAT_UTEN_ARBEIDSGIVER
+    ADD COLUMN tilfelle_start DATE;
+
+UPDATE KANDIDAT_UTEN_ARBEIDSGIVER k
+SET tilfelle_start = COALESCE(
+    (
+        SELECT (tilfelle->>'start')::date
+        FROM OPPFOLGINGSTILFELLE_PERSON op,
+             jsonb_array_elements(op.oppfolgingstilfeller) AS tilfelle
+        WHERE op.personident = k.personident
+          AND op.created_at <= k.created_at
+        ORDER BY op.created_at DESC, (tilfelle->>'start')::date DESC
+        LIMIT 1
+    ),
+    k.created_at::date
+)
+WHERE tilfelle_start IS NULL;
+
+ALTER TABLE KANDIDAT_UTEN_ARBEIDSGIVER
+    ALTER COLUMN tilfelle_start SET NOT NULL;

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
@@ -22,7 +22,9 @@ import testhelper.UserConstants.VIRKSOMHETSNUMMER_DEFAULT
 import testhelper.countKandidater
 import testhelper.dropData
 import testhelper.generator.generateKafkaSyketilfellebitRelevantSykmeldingBekreftet
+import testhelper.insertKandidatFerdig
 import testhelper.mock.toHistoricalPersonIdentNumber
+import testhelper.setKandidatFerdig
 import java.time.Duration
 import java.time.LocalDate
 
@@ -205,22 +207,15 @@ class OppfolgingstilfelleCronjobKandidatTest {
 
     @Test
     fun `stores new kandidat for new tilfelle when previous kandidat is FERDIG`() {
-        val bit1 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
-            personIdentNumber = personIdentDefault,
-            fom = LocalDate.now().minusDays(30),
-            tom = LocalDate.now().minusDays(2),
-        )
-        pollAndRun(listOf(bit1))
+        database.insertKandidatFerdig(personIdentDefault, LocalDate.now().minusDays(60))
         assertEquals(1, database.countKandidater())
 
-        database.setKandidatFerdig()
-
-        val bit2 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+        val bit = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
             personIdentNumber = personIdentDefault,
-            fom = LocalDate.now().minusDays(1),
+            fom = LocalDate.now().minusDays(10),
             tom = LocalDate.now(),
         )
-        pollAndRun(listOf(bit2))
+        pollAndRun(listOf(bit))
         assertEquals(2, database.countKandidater())
     }
 }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/OppfolgingstilfelleCronjobKandidatTest.kt
@@ -180,4 +180,47 @@ class OppfolgingstilfelleCronjobKandidatTest {
         pollAndRun(listOf(bekreftetBit))
         assertEquals(0, database.countKandidater())
     }
+
+    @Test
+    fun `does not store new kandidat for same tilfelle when previous kandidat is FERDIG`() {
+        val fom = LocalDate.now().minusDays(30)
+        val bit1 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = fom,
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit1))
+        assertEquals(1, database.countKandidater())
+
+        database.setKandidatFerdig()
+
+        val bit2 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = fom,
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit2))
+        assertEquals(1, database.countKandidater())
+    }
+
+    @Test
+    fun `stores new kandidat for new tilfelle when previous kandidat is FERDIG`() {
+        val bit1 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(30),
+            tom = LocalDate.now().minusDays(2),
+        )
+        pollAndRun(listOf(bit1))
+        assertEquals(1, database.countKandidater())
+
+        database.setKandidatFerdig()
+
+        val bit2 = generateKafkaSyketilfellebitRelevantSykmeldingBekreftet(
+            personIdentNumber = personIdentDefault,
+            fom = LocalDate.now().minusDays(1),
+            tom = LocalDate.now(),
+        )
+        pollAndRun(listOf(bit2))
+        assertEquals(2, database.countKandidater())
+    }
 }

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -85,6 +85,13 @@ fun DatabaseInterface.countKandidater() =
         }
     }
 
+fun DatabaseInterface.setKandidatFerdig() {
+    this.connection.use { connection ->
+        connection.prepareStatement("UPDATE KANDIDAT_UTEN_ARBEIDSGIVER SET status = 'FERDIG'").execute()
+        connection.commit()
+    }
+}
+
 const val queryGetOppfolgingstilfelleBitForIdent =
     """
     SELECT *

--- a/src/test/kotlin/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/testhelper/TestDatabase.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.infrastructure.database.bit.toPOppfolgingstilfelleBit
 import no.nav.syfo.infrastructure.database.toList
 import org.flywaydb.core.Flyway
 import java.sql.Connection
+import java.time.LocalDate
 
 class TestDatabase : DatabaseInterface {
     private val pg: EmbeddedPostgres
@@ -88,6 +89,23 @@ fun DatabaseInterface.countKandidater() =
 fun DatabaseInterface.setKandidatFerdig() {
     this.connection.use { connection ->
         connection.prepareStatement("UPDATE KANDIDAT_UTEN_ARBEIDSGIVER SET status = 'FERDIG'").execute()
+        connection.commit()
+    }
+}
+
+fun DatabaseInterface.insertKandidatFerdig(personident: PersonIdentNumber, tilfelleStart: LocalDate) {
+    this.connection.use { connection ->
+        connection.prepareStatement(
+            """
+            INSERT INTO KANDIDAT_UTEN_ARBEIDSGIVER (uuid, created_at, personident, aktor_id, tilfelle_start, status, next_processing_at)
+            VALUES (?, now(), ?, 'test-aktor-id', ?, 'FERDIG', now())
+            """
+        ).use {
+            it.setString(1, java.util.UUID.randomUUID().toString())
+            it.setString(2, personident.value)
+            it.setObject(3, tilfelleStart)
+            it.executeUpdate()
+        }
         connection.commit()
     }
 }


### PR DESCRIPTION
Forbedrer koden for å unngå at det blir mer enn en oversending til Modia AO per oppfølgingstilfelle.