### PR TITLE
Add logs to Modia/AO kandidatoversending

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonApi.kt
@@ -5,9 +5,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.application.OppfolgingstilfelleService
-import no.nav.syfo.domain.Oppfolgingstilfelle
 import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.domain.hasGjentakendeSykefravar
+import no.nav.syfo.domain.defaultEmptyOppfolgingstilfellePersonDTO
 import no.nav.syfo.domain.toOppfolgingstilfellePersonDTO
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.util.*
@@ -19,24 +18,22 @@ fun Route.registerOppfolgingstilfelleApi(
 ) {
     route("/api/internad/v1/oppfolgingstilfelle") {
         get("/personident") {
-            val personIdent = personIdentHeader()?.let { personIdent ->
+            val personident = personIdentHeader()?.let { personIdent ->
                 PersonIdentNumber(personIdent)
             }
                 ?: throw IllegalArgumentException("Failed to retrieve OppfolgingstilfelleDTO: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
             validateVeilederAccess(
                 action = "Read OppfolgingstilfelleDTO for Person with PersonIdent",
-                personIdentToAccess = personIdent,
+                personIdentToAccess = personident,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
             ) {
-                val dodsdato = oppfolgingstilfelleService.getDodsdato(personIdent)
+                val dodsdato = oppfolgingstilfelleService.getDodsdato(personident)
                 val oppfolgingstilfellePersonDTO =
-                    oppfolgingstilfelleService.getOppfolgingstilfellePerson(personIdent = personIdent)
-                        ?.toOppfolgingstilfellePersonDTO() ?: OppfolgingstilfellePersonDTO(
-                        oppfolgingstilfelleList = emptyList(),
-                        personIdent = personIdent.value,
-                        dodsdato = dodsdato,
-                        hasGjentakendeSykefravar = emptyList<Oppfolgingstilfelle>().hasGjentakendeSykefravar()
+                    oppfolgingstilfelleService.getOppfolgingstilfellePerson(personIdent = personident)
+                        ?.toOppfolgingstilfellePersonDTO() ?: defaultEmptyOppfolgingstilfellePersonDTO(
+                        personident.value,
+                        dodsdato
                     )
                 call.respond(oppfolgingstilfellePersonDTO)
             }
@@ -55,11 +52,9 @@ fun Route.registerOppfolgingstilfelleApi(
                 personIdentsWithVeilederAccess.map {
                     val dodsdato = oppfolgingstilfelleService.getDodsdato(it)
                     oppfolgingstilfelleService.getOppfolgingstilfellePerson(personIdent = it)
-                        ?.toOppfolgingstilfellePersonDTO() ?: OppfolgingstilfellePersonDTO(
-                        oppfolgingstilfelleList = emptyList(),
-                        personIdent = it.value,
-                        dodsdato = dodsdato,
-                        hasGjentakendeSykefravar = emptyList<Oppfolgingstilfelle>().hasGjentakendeSykefravar(),
+                        ?.toOppfolgingstilfellePersonDTO() ?: defaultEmptyOppfolgingstilfellePersonDTO(
+                        it.value,
+                        dodsdato
                     )
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonDTO.kt
@@ -1,8 +1,10 @@
 package no.nav.syfo.api.endpoints
 
 import java.time.LocalDate
+import java.util.UUID
 
 data class OppfolgingstilfellePersonDTO(
+    val uuid: UUID,
     val oppfolgingstilfelleList: List<OppfolgingstilfelleDTO>,
     val personIdent: String,
     val dodsdato: LocalDate?,

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonSystemApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingstilfellePersonSystemApi.kt
@@ -4,9 +4,8 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.api.access.APIConsumerAccessService
 import no.nav.syfo.application.OppfolgingstilfelleService
-import no.nav.syfo.domain.Oppfolgingstilfelle
 import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.domain.hasGjentakendeSykefravar
+import no.nav.syfo.domain.defaultEmptyOppfolgingstilfellePersonDTO
 import no.nav.syfo.domain.toOppfolgingstilfellePersonDTO
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.getBearerHeader
@@ -28,19 +27,17 @@ fun Route.registerOppfolgingstilfelleSystemApi(
                 authorizedApplicationNames = authorizedApplicationNames,
                 token = token,
             )
-            val personIdent = personIdentHeader()?.let { personIdent ->
+            val personident = personIdentHeader()?.let { personIdent ->
                 PersonIdentNumber(personIdent)
             }
                 ?: throw IllegalArgumentException("Failed to retrieve OppfolgingstilfelleDTO: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
-            val dodsdato = oppfolgingstilfelleService.getDodsdato(personIdent)
+            val dodsdato = oppfolgingstilfelleService.getDodsdato(personident)
             val oppfolgingstilfellePersonDTO =
-                oppfolgingstilfelleService.getOppfolgingstilfellePerson(personIdent = personIdent)
-                    ?.toOppfolgingstilfellePersonDTO() ?: OppfolgingstilfellePersonDTO(
-                    oppfolgingstilfelleList = emptyList(),
-                    personIdent = personIdent.value,
-                    dodsdato = dodsdato,
-                    hasGjentakendeSykefravar = emptyList<Oppfolgingstilfelle>().hasGjentakendeSykefravar(),
+                oppfolgingstilfelleService.getOppfolgingstilfellePerson(personIdent = personident)
+                    ?.toOppfolgingstilfellePersonDTO() ?: defaultEmptyOppfolgingstilfellePersonDTO(
+                    personident.value,
+                    dodsdato
                 )
             call.respond(oppfolgingstilfellePersonDTO)
         }

--- a/src/main/kotlin/no/nav/syfo/domain/OppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/OppfolgingstilfellePerson.kt
@@ -50,10 +50,19 @@ data class Oppfolgingstilfelle(
 }
 
 fun OppfolgingstilfellePerson.toOppfolgingstilfellePersonDTO() = OppfolgingstilfellePersonDTO(
+    uuid = this.uuid,
     oppfolgingstilfelleList = this.oppfolgingstilfelleList.toOppfolgingstilfelleDTOList(),
     personIdent = this.personIdentNumber.value,
     dodsdato = this.dodsdato,
     hasGjentakendeSykefravar = this.hasGjentakendeSykefravar,
+)
+
+fun defaultEmptyOppfolgingstilfellePersonDTO(personident: String, dodsdato: LocalDate?) = OppfolgingstilfellePersonDTO(
+    uuid = UUID.randomUUID(),
+    oppfolgingstilfelleList = emptyList(),
+    personIdent = personident,
+    dodsdato = dodsdato,
+    hasGjentakendeSykefravar = emptyList<Oppfolgingstilfelle>().hasGjentakendeSykefravar(),
 )
 
 fun List<Oppfolgingstilfelle>.toOppfolgingstilfelleDTOList() =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/ModiaAOOversendingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/ModiaAOOversendingCronjob.kt
@@ -70,6 +70,11 @@ class ModiaAOOversendingCronjob(
 
                     else -> {
                         kandidatRepository.markerFerdig(kandidat.uuid)
+                        log.info(
+                            "Kandidat ferdigstilles fordi siste oppfolgingstilfelle har arbeidsgiver, {}, {}",
+                            StructuredArguments.keyValue("kandidatUuid", kandidat.uuid),
+                            StructuredArguments.keyValue("oppfolgingstilfellePersonUuid", oppfolgingstilfellePerson.uuid),
+                        )
                     }
                 }
                 result.updated++


### PR DESCRIPTION
Logger når en kandidat kommer til defaulttilfellet under oversending. Hensikten her er i prinsippet at kandidaten skal ha arbeidsgiver, og derfor ikke skal oversendes. Siden vi ikke er helt sikre på hvilke kandidater som havner i defaulttilfellet, så legger vi til en log her.

NB: Dette blir egentlig å påvirke APIet, siden jeg tukler med `toOppfolgingstilfellePersonDTO()`. Kanskje man skulle laget en egen funksjon med UUID inkludert? Spørs hvordan konsumentene av APIet reagerer på dette.